### PR TITLE
Update backend to use OpenAI Responses API

### DIFF
--- a/cloud-function/package.json
+++ b/cloud-function/package.json
@@ -12,6 +12,7 @@
     "axios": "^1.6.8",
     "cors": "^2.8.5",
     "express": "^4.19.2",
-    "google-auth-library": "^9.7.0"
+    "google-auth-library": "^9.7.0",
+    "openai": "^4.52.2"
   }
 }


### PR DESCRIPTION
## Summary
- add the official OpenAI SDK to the Cloud Function dependencies
- replace the backend implementation with an Express server that calls the OpenAI Responses API for chore classification and avatar generation

## Testing
- `npm install --prefix cloud-function` *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/openai)*

------
https://chatgpt.com/codex/tasks/task_e_68cf191ded8c83218c65f0a6e5be2921