### PR TITLE
Externalize client configuration secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 config.js
+node_modules/
+cloud-function/node_modules/

--- a/config.example.js
+++ b/config.example.js
@@ -1,0 +1,14 @@
+// Copy this file to config.js and replace the placeholder values with your
+// real configuration. Do not commit config.js to version control.
+window.__CODEX_CONFIG__ = {
+  firebaseConfig: {
+    apiKey: "YOUR_FIREBASE_API_KEY",
+    authDomain: "YOUR_FIREBASE_AUTH_DOMAIN",
+    projectId: "YOUR_FIREBASE_PROJECT_ID",
+    storageBucket: "YOUR_FIREBASE_STORAGE_BUCKET",
+    messagingSenderId: "YOUR_FIREBASE_MESSAGING_SENDER_ID",
+    appId: "YOUR_FIREBASE_APP_ID",
+    measurementId: "YOUR_FIREBASE_MEASUREMENT_ID"
+  },
+  backendUrl: "https://your-backend-endpoint.example.com"
+};

--- a/index.html
+++ b/index.html
@@ -231,9 +231,11 @@
     <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-storage.js"></script>
     
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.0/p5.js"></script>
-    
-    <script src="js/skill-tree-data.js"></script> 
+
+    <script src="js/skill-tree-data.js"></script>
     <script src="js/skill-tree-sketch.js"></script>
+    <!-- Configuration values (firebase config, backend URL) -->
+    <script src="config.js"></script>
     <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,19 +1,30 @@
 // js/main.js
 
 // --- CONFIGURATION ---
-const firebaseConfig = {
-    apiKey: "AIzaSyDqCT_iOBToHDR7sRQnH_mUmwN5V_RXj58",
-    authDomain: "codex-vitae-app.firebaseapp.com",
-    projectId: "codex-vitae-app",
-    storageBucket: "codex-vitae-app.firebasestorage.app",
-    messagingSenderId: "1078038224886",
-    appId: "1:1078038224886:web:19a322f88fc529307371d7",
-    measurementId: "G-DVGVB274T3"
-};
+// Sensitive configuration values are now injected via config.js which
+// should define window.__CODEX_CONFIG__.
+const codexConfig = window.__CODEX_CONFIG__;
 
-// --- UPDATED: Server URL ---
-// This now points to the backend server you deployed.
-const BACKEND_SERVER_URL = 'https://codex-vitae-backend-1078038224886.us-central1.run.app';
+if (!codexConfig || typeof codexConfig !== 'object') {
+    throw new Error(
+        'Codex Vitae configuration is missing. Define window.__CODEX_CONFIG__ in config.js.'
+    );
+}
+
+const firebaseConfig = codexConfig.firebaseConfig;
+const BACKEND_SERVER_URL = codexConfig.backendUrl;
+
+if (!firebaseConfig || typeof firebaseConfig !== 'object') {
+    throw new Error(
+        'Firebase configuration is missing. Ensure config.js exports firebaseConfig.'
+    );
+}
+
+if (typeof BACKEND_SERVER_URL !== 'string' || BACKEND_SERVER_URL.trim().length === 0) {
+    throw new Error(
+        'Backend server URL is missing. Ensure config.js exports backendUrl.'
+    );
+}
 
 // --- Firebase Initialization ---
 firebase.initializeApp(firebaseConfig);


### PR DESCRIPTION
## Summary
- load Firebase credentials and backend URL from a runtime-provided config.js instead of hardcoding them
- add a config.example.js template and include the new script in the HTML bootstrap
- ignore local node_modules directories alongside the untracked config.js secret file

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cf23b40a908321ba2941ea56554e27