### PR TITLE
Surface missing configuration in auth screen

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -87,6 +87,16 @@ p {
     border: 1px solid rgba(255, 255, 255, 0.65);
 }
 
+.config-error-message {
+    color: #b00020;
+    font-weight: 700;
+}
+
+.config-error-details {
+    color: var(--color-text-medium);
+    margin-bottom: 12px;
+}
+
 #auth-screen button {
     margin-top: 5px;
 }


### PR DESCRIPTION
## Summary
- add a helper that renders a friendly configuration error inside the auth screen before throwing
- highlight missing Firebase credentials or backend URL with actionable instructions instead of failing silently
- style the config error copy so it is easy to spot while keeping the auth card layout intact

## Testing
- node --check js/main.js

------
https://chatgpt.com/codex/tasks/task_e_68cf3fb504d88321acfab73c1ecec695