### PR TITLE
Return backend to Vertex AI for generation

### DIFF
--- a/cloud-function/package.json
+++ b/cloud-function/package.json
@@ -12,7 +12,6 @@
     "axios": "^1.6.8",
     "cors": "^2.8.5",
     "express": "^4.19.2",
-    "google-auth-library": "^9.7.0",
-    "openai": "^4.52.2"
+    "google-auth-library": "^9.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- replace the backend OpenAI client with a Vertex AI integration authenticated via google-auth-library
- update chore classification to call Gemini on Vertex and keep the JSON parsing safeguards
- fix avatar generation by invoking Vertex image generation with inline image data and returning the generated asset

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cff7aa341883218dc566205f6780b6