### PR TITLE
Update backend URL to production service

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,5 +7,5 @@ window.__CODEX_CONFIG__ = {
     messagingSenderId: "107802832688486",
     appId: "1:107802832688486:web:3d4c2f40568f6fa4569ad5"
   },
-  backendUrl: "http://localhost:8080"
+  backendUrl: "https://codex-vitae-backend-1078038224886.us-central1.run.app"
 };


### PR DESCRIPTION
## Summary
- point the frontend configuration at the deployed Codex Vitae backend so runtime calls use the production service

## Testing
- node - <<'NODE' (fails: outbound network is blocked in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d0362350548321a9deb8287012b365