### PR TITLE
Add star detail panel and controller for skill tree

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,17 +202,35 @@
         </div>
     </div>
 
-    <div id="skills-modal" class="modal hidden">
-        <div class="modal-content">
-            <div id="skill-tree-header">
-                <button id="skill-back-btn" class="hidden">&larr; Back</button>
-                <h2 id="skill-tree-title">Skill Galaxy</h2>
-                <button id="close-skills-btn">Close</button>
+        <div id="skills-modal" class="modal hidden">
+            <div class="modal-content">
+                <div id="skill-tree-header">
+                    <button id="skill-back-btn" class="hidden">&larr; Back</button>
+                    <h2 id="skill-tree-title">Skill Galaxy</h2>
+                    <button id="close-skills-btn">Close</button>
+                </div>
+                <div id="skill-tree-breadcrumbs"></div>
+                <div id="skill-tree-canvas-container"></div>
+                <div id="star-detail-panel" class="hidden">
+                    <div class="star-detail-header">
+                        <div class="star-detail-title-group">
+                            <div id="star-detail-art" class="star-detail-art" aria-hidden="true"></div>
+                            <div class="star-detail-text">
+                                <h3 id="star-detail-title"></h3>
+                                <p id="star-detail-location" class="star-detail-location"></p>
+                            </div>
+                        </div>
+                        <button id="star-detail-close" type="button" aria-label="Close star details">&times;</button>
+                    </div>
+                    <p id="star-detail-description" class="star-detail-description"></p>
+                    <div id="star-detail-requirements" class="star-detail-requirements"></div>
+                    <div id="star-detail-actions" class="star-detail-actions">
+                        <button id="star-unlock-btn" type="button">Unlock</button>
+                        <button id="star-proof-btn" type="button">Provide Proof</button>
+                    </div>
+                </div>
             </div>
-            <div id="skill-tree-breadcrumbs"></div>
-            <div id="skill-tree-canvas-container"></div>
         </div>
-    </div>
 
     <div id="codex-modal" class="modal hidden">
         <div class="modal-content">


### PR DESCRIPTION
## Summary
- add a detail panel inside the skills modal to display star art, description, requirements, and actions
- introduce a controller that populates the panel, handles unlocking perks, and integrates credential placeholders
- update the skill tree sketch to open the detail panel on selection and keep canvas state synchronized

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d095619b38832187622b2accfb410f