### PR TITLE
Add pannable constellation belt with accessibility controls

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -375,6 +375,12 @@ button:active {
     box-shadow: 0 8px 14px rgba(63, 111, 118, 0.28);
 }
 
+.skill-tree-pan-button:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
 #skill-tree-canvas-container {
     border: 1px solid rgba(255, 255, 255, 0.12);
     border-radius: 18px;

--- a/CSS/style.css
+++ b/CSS/style.css
@@ -347,6 +347,32 @@ button:active {
     align-items: center;
     margin-bottom: 24px;
     color: #e7edf0;
+    gap: 12px;
+}
+
+#skill-tree-controls {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+#skill-tree-pan-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.skill-tree-pan-button {
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.1em;
+    line-height: 1;
+    box-shadow: 0 8px 14px rgba(63, 111, 118, 0.28);
 }
 
 #skill-tree-canvas-container {

--- a/index.html
+++ b/index.html
@@ -205,9 +205,15 @@
     <div id="skills-modal" class="modal hidden">
         <div class="modal-content">
             <div id="skill-tree-header">
-                <button id="skill-back-btn" class="hidden">&larr; Back</button>
+                <div id="skill-tree-controls">
+                    <button id="skill-back-btn" class="hidden" type="button">&larr; Back</button>
+                    <div id="skill-tree-pan-controls" class="hidden" role="group" aria-label="Constellation pan controls">
+                        <button id="skill-pan-left" class="skill-tree-pan-button" type="button" aria-label="Nudge constellations left">&#8592;</button>
+                        <button id="skill-pan-right" class="skill-tree-pan-button" type="button" aria-label="Nudge constellations right">&#8594;</button>
+                    </div>
+                </div>
                 <h2 id="skill-tree-title">Skill Galaxy</h2>
-                <button id="close-skills-btn">Close</button>
+                <button id="close-skills-btn" type="button">Close</button>
             </div>
             <div id="skill-tree-breadcrumbs"></div>
             <div id="skill-tree-canvas-container"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -520,6 +520,7 @@ function updateSkillTreeUI(title, breadcrumbs, showBack) {
     if (skillTreePanControls) {
         const showPanControls = Array.isArray(breadcrumbs) && breadcrumbs.length === 2;
         skillTreePanControls.classList.toggle('hidden', !showPanControls);
+        skillTreePanControls.setAttribute('aria-hidden', showPanControls ? 'false' : 'true');
         if (skillPanLeftBtn) {
             skillPanLeftBtn.disabled = !showPanControls;
         }

--- a/js/main.js
+++ b/js/main.js
@@ -77,6 +77,11 @@ const appScreen = document.getElementById('app-screen');
 const skillsModal = document.getElementById('skills-modal');
 const skillTreeTitle = document.getElementById('skill-tree-title');
 const skillBackBtn = document.getElementById('skill-back-btn');
+const skillTreePanControls = document.getElementById('skill-tree-pan-controls');
+const skillPanLeftBtn = document.getElementById('skill-pan-left');
+const skillPanRightBtn = document.getElementById('skill-pan-right');
+
+const CONSTELLATION_PAN_NUDGE = 80;
 
 // --- Global Data Variables ---
 let characterData = {};
@@ -511,6 +516,17 @@ function updateSkillTreeUI(title, breadcrumbs, showBack) {
     skillTreeTitle.textContent = title;
     document.getElementById('skill-tree-breadcrumbs').textContent = breadcrumbs.join(' > ');
     skillBackBtn.classList.toggle('hidden', !showBack);
+
+    if (skillTreePanControls) {
+        const showPanControls = Array.isArray(breadcrumbs) && breadcrumbs.length === 2;
+        skillTreePanControls.classList.toggle('hidden', !showPanControls);
+        if (skillPanLeftBtn) {
+            skillPanLeftBtn.disabled = !showPanControls;
+        }
+        if (skillPanRightBtn) {
+            skillPanRightBtn.disabled = !showPanControls;
+        }
+    }
 }
 
 function showToast(message) { 
@@ -552,12 +568,26 @@ function setupEventListeners() {
     });
     document.getElementById('codex-logout-btn').addEventListener('click', handleLogout);
     document.getElementById('close-skills-btn').addEventListener('click', () => document.getElementById('skills-modal').classList.add('hidden'));
-    
+
+    const nudgeConstellations = (delta) => {
+        if (myp5 && typeof myp5.adjustConstellationOffset === 'function') {
+            myp5.adjustConstellationOffset(delta);
+        }
+    };
+
+    if (skillPanLeftBtn) {
+        skillPanLeftBtn.addEventListener('click', () => nudgeConstellations(-CONSTELLATION_PAN_NUDGE));
+    }
+
+    if (skillPanRightBtn) {
+        skillPanRightBtn.addEventListener('click', () => nudgeConstellations(CONSTELLATION_PAN_NUDGE));
+    }
+
     skillBackBtn.addEventListener('click', () => {
         if (myp5) {
             myp5.goBack();
         }
-     });
+    });
     document.getElementById('scan-face-btn').addEventListener('click', handleFaceScan);
 
     listenersInitialized = true;


### PR DESCRIPTION
## Summary
- add a horizontal pan state to the constellation view, applying it when preparing data and clamping the bounds so constellations stay visible
- support mouse dragging and programmatic nudges for the constellation belt while keeping selection behavior intact
- surface and style header nudge controls to access the new pan behavior without dragging

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d09580e3788321bfa97311eee49489