### PR TITLE
Add skill tree search navigation

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -345,8 +345,80 @@ button:active {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
     margin-bottom: 24px;
     color: #e7edf0;
+    position: relative;
+    z-index: 5;
+}
+
+#skill-tree-header h2 {
+    flex: 1 1 auto;
+    text-align: center;
+    margin: 0;
+}
+
+.skill-tree-controls {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-left: auto;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    min-width: 0;
+}
+
+#skill-search-form {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: rgba(20, 33, 42, 0.82);
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    flex: 1 1 220px;
+    min-width: 0;
+    box-shadow: 0 12px 26px rgba(10, 16, 20, 0.35);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+#skill-search-form.search-active,
+#skill-search-form:focus-within {
+    border-color: rgba(245, 178, 103, 0.9);
+    background: rgba(20, 33, 42, 0.92);
+    box-shadow: 0 14px 32px rgba(245, 178, 103, 0.28);
+}
+
+#skill-search-input {
+    flex: 1 1 auto;
+    border: none;
+    background: transparent;
+    color: #f6f9fb;
+    padding: 6px 0;
+    font-size: 0.95em;
+}
+
+#skill-search-input::placeholder {
+    color: rgba(231, 236, 240, 0.65);
+}
+
+#skill-search-input:focus {
+    outline: none;
+    box-shadow: none;
+}
+
+#skill-search-form button {
+    padding: 8px 16px;
+    border-radius: 999px;
+    font-size: 0.85em;
+    background: linear-gradient(135deg, var(--color-accent) 0%, #f58d54 100%);
+    color: #2c190b;
+    box-shadow: 0 8px 18px rgba(245, 178, 103, 0.28);
+}
+
+#skill-search-form button:hover {
+    box-shadow: 0 12px 24px rgba(245, 178, 103, 0.34);
 }
 
 #skill-tree-canvas-container {

--- a/CSS/style.css
+++ b/CSS/style.css
@@ -349,8 +349,15 @@ button:active {
     flex-wrap: wrap;
     margin-bottom: 24px;
     color: #e7edf0;
-    position: relative;
+    position: sticky;
+    top: 0;
     z-index: 5;
+    padding: 16px 18px;
+    background: linear-gradient(145deg, rgba(15, 27, 36, 0.92), rgba(28, 42, 52, 0.88));
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 20px;
+    box-shadow: 0 18px 32px rgba(8, 12, 18, 0.55);
+    backdrop-filter: blur(8px);
 }
 
 #skill-tree-header h2 {

--- a/index.html
+++ b/index.html
@@ -209,7 +209,13 @@
                 <h2 id="skill-tree-title">Skill Galaxy</h2>
                 <div class="skill-tree-controls">
                     <form id="skill-search-form" class="skill-tree-search" role="search">
-                        <input type="search" id="skill-search-input" placeholder="Search galaxy, constellation, or star..." aria-label="Search skills" autocomplete="off">
+                        <input
+                            type="search"
+                            id="skill-search-input"
+                            placeholder="Search galaxy, constellation, or star..."
+                            aria-label="Search skills"
+                            autocomplete="off"
+                        >
                         <button type="submit" id="skill-search-button">Search</button>
                     </form>
                     <button id="close-skills-btn">Close</button>

--- a/index.html
+++ b/index.html
@@ -207,7 +207,13 @@
             <div id="skill-tree-header">
                 <button id="skill-back-btn" class="hidden">&larr; Back</button>
                 <h2 id="skill-tree-title">Skill Galaxy</h2>
-                <button id="close-skills-btn">Close</button>
+                <div class="skill-tree-controls">
+                    <form id="skill-search-form" class="skill-tree-search" role="search">
+                        <input type="search" id="skill-search-input" placeholder="Search galaxy, constellation, or star..." aria-label="Search skills" autocomplete="off">
+                        <button type="submit" id="skill-search-button">Search</button>
+                    </form>
+                    <button id="close-skills-btn">Close</button>
+                </div>
             </div>
             <div id="skill-tree-breadcrumbs"></div>
             <div id="skill-tree-canvas-container"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -607,20 +607,32 @@ function setupEventListeners() {
         activityManager.logActivity(document.getElementById('activity-select').value);
     });
     
-    document.getElementById('open-codex-btn').addEventListener('click', () => document.getElementById('codex-modal').classList.remove('hidden'));
-    document.getElementById('close-codex-btn').addEventListener('click', () => document.getElementById('codex-modal').classList.add('hidden'));
+    const codexModal = document.getElementById('codex-modal');
+
+    document.getElementById('open-codex-btn').addEventListener('click', () => {
+        codexModal.classList.remove('hidden');
+    });
+
+    document.getElementById('close-codex-btn').addEventListener('click', () => {
+        codexModal.classList.add('hidden');
+    });
+
     document.getElementById('codex-skills-btn').addEventListener('click', () => {
-        document.getElementById('codex-modal').classList.add('hidden');
+        codexModal.classList.add('hidden');
         openSkillsModal();
     });
+
     document.getElementById('codex-logout-btn').addEventListener('click', handleLogout);
-    document.getElementById('close-skills-btn').addEventListener('click', () => document.getElementById('skills-modal').classList.add('hidden'));
+
+    document.getElementById('close-skills-btn').addEventListener('click', () => {
+        skillsModal.classList.add('hidden');
+    });
     
     skillBackBtn.addEventListener('click', () => {
         if (myp5) {
             myp5.goBack();
         }
-     });
+    });
 
     if (skillSearchForm && skillSearchInput) {
         const toggleSearchFocus = (isActive) => {

--- a/js/skill-tree-sketch.js
+++ b/js/skill-tree-sketch.js
@@ -264,10 +264,8 @@ function sketch(p) {
     // --- Public function for the back button ---
     p.navigateToPath = function(path) {
         if (!path || !path.galaxy || !skillTree[path.galaxy]) {
-            return;
+            return false;
         }
-
-        resetNavigationQueue();
 
         const wantsConstellation = !!path.constellation;
         const wantsStar = path.type === 'star' && !!path.star;
@@ -275,6 +273,12 @@ function sketch(p) {
         const targetStarExists = wantsStar
             && targetConstellationExists
             && !!skillTree[path.galaxy].constellations[path.constellation].stars?.[path.star];
+
+        if ((wantsConstellation && !targetConstellationExists) || (wantsStar && !targetStarExists)) {
+            return false;
+        }
+
+        resetNavigationQueue();
 
         const steps = [];
         const stepDelay = 240;
@@ -305,12 +309,14 @@ function sketch(p) {
         }
 
         if (path.type === 'galaxy') {
-            scheduleStep(() => {
-                currentView = 'galaxies';
-                selectedGalaxy = path.galaxy;
-                selectedConstellation = null;
-                prepareGalaxyData();
-            });
+            if (currentView !== 'galaxies' || selectedGalaxy !== path.galaxy) {
+                scheduleStep(() => {
+                    currentView = 'galaxies';
+                    selectedGalaxy = path.galaxy;
+                    selectedConstellation = null;
+                    prepareGalaxyData();
+                });
+            }
         } else {
             scheduleStep(() => {
                 currentView = 'constellations';
@@ -342,7 +348,7 @@ function sketch(p) {
             if (typeof p.redraw === 'function') {
                 p.redraw();
             }
-            return;
+            return true;
         }
 
         steps[0]();
@@ -351,6 +357,8 @@ function sketch(p) {
             const timeoutId = setTimeout(steps[i], i * stepDelay);
             pendingNavigationTimeouts.push(timeoutId);
         }
+
+        return true;
     };
 
     p.goBack = function() {


### PR DESCRIPTION
## Summary
- add a search form to the skill tree header so users can look up galaxies, constellations, or stars
- style the new search controls to remain visible above the canvas and match the codex theme
- wire the search form to traverse the skill tree, persist the last search target, and highlight destinations across p5 layers

## Testing
- No automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d0955505848321835aee88566e057a