### PR TITLE
Expand skill modal dimensions

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -335,6 +335,37 @@ button:active {
     background: linear-gradient(155deg, rgba(47, 63, 72, 0.95), rgba(34, 46, 52, 0.95));
     border: 1px solid rgba(255, 255, 255, 0.1);
     box-shadow: 0 18px 35px rgba(10, 16, 20, 0.55);
+    width: min(95vw, 1200px);
+    max-width: min(95vw, 1200px);
+    height: min(90vh, 95vh);
+    max-height: 95vh;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    overflow-y: auto;
+    scrollbar-gutter: stable both-edges;
+}
+
+#skills-modal .modal-content > * {
+    width: 100%;
+}
+
+#skills-modal #skill-tree-header,
+#skills-modal #skill-tree-breadcrumbs {
+    flex-shrink: 0;
+}
+
+#skills-modal #skill-tree-canvas-container {
+    flex: 1 1 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+#skills-modal #star-detail-panel {
+    flex: 1 1 0;
+    min-height: 0;
+    overflow-y: auto;
 }
 
 #skills-modal h2 {


### PR DESCRIPTION
## Summary
- widen and heighten the skills modal using viewport-based sizing while keeping other modals compact
- switch the skills modal content to a flex column so the header, canvas container, and detail panel stretch and scroll together

## Testing
- python -m http.server 8000
- manual validation in Chromium via Playwright at desktop (1280×720) and small viewport (480×800)


------
https://chatgpt.com/codex/tasks/task_e_68d175c7d6588321bae9bf31fa81b496