### PR TITLE
Make skill tree canvas responsive to container resizing

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -970,16 +970,32 @@ function restoreSkillSearchTargetNavigation() {
 }
 
 function openSkillsModal() {
+    starDetailController.hide();
+
+    const canHandleResize = myp5 && typeof myp5.handleResize === 'function';
+
+    if (canHandleResize) {
+        myp5.handleResize();
+    } else if (myp5 && typeof myp5.prepareStarData === 'function') {
+        myp5.prepareStarData();
+    }
+
     skillsModal.classList.remove('hidden');
     syncSkillSearchInputWithTarget();
     restoreSkillSearchTargetNavigation();
-}
-function openSkillsModal() {
-    starDetailController.hide();
-    if (myp5 && typeof myp5.prepareStarData === 'function') {
+
+    if (canHandleResize) {
+        const schedule = typeof requestAnimationFrame === 'function'
+            ? requestAnimationFrame
+            : (fn) => setTimeout(fn, 0);
+        schedule(() => {
+            if (myp5 && typeof myp5.handleResize === 'function') {
+                myp5.handleResize();
+            }
+        });
+    } else if (myp5 && typeof myp5.prepareStarData === 'function') {
         myp5.prepareStarData();
     }
-    skillsModal.classList.remove('hidden');
 }
 
 function updateSkillTreeUI(title, breadcrumbs, showBack) {


### PR DESCRIPTION
## Summary
- size the skill tree canvas off of its container (or viewport fallback) instead of hard-coded dimensions
- recalculate galaxy, constellation, and star positions whenever the window or container resizes
- update the skills modal opener to trigger the resize handler before showing the canvas

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1780f460c832188d8ef36a3e76b12