### PR TITLE
Add hero avatar placeholder and styling

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -262,15 +262,91 @@ button:active {
 }
 
 /* --- FACE SCAN & AVATAR --- */
+.avatar-hero {
+    position: relative;
+    margin: -14px -10px 6px;
+    padding: 38px 28px 48px;
+    border-radius: 42px;
+    background:
+        radial-gradient(circle at 18% 18%, rgba(247, 226, 173, 0.45), transparent 62%),
+        radial-gradient(circle at 78% 22%, rgba(127, 178, 123, 0.32), transparent 70%),
+        linear-gradient(165deg, rgba(223, 232, 242, 0.92), rgba(249, 243, 234, 0.96));
+    box-shadow: 0 32px 60px rgba(38, 68, 75, 0.22);
+    border: 1px solid rgba(255, 255, 255, 0.7);
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 18px;
+    overflow: hidden;
+    isolation: isolate;
+}
+
+.avatar-hero::before {
+    content: "";
+    position: absolute;
+    inset: -40% -46% 38% -46%;
+    background:
+        radial-gradient(circle at 28% 32%, rgba(255, 255, 255, 0.65), transparent 62%),
+        radial-gradient(circle at 72% 48%, rgba(247, 178, 103, 0.4), transparent 70%);
+    opacity: 0.85;
+    pointer-events: none;
+    z-index: -2;
+}
+
+.avatar-hero::after {
+    content: "";
+    position: absolute;
+    inset: 46% -48% -30% -48%;
+    background: radial-gradient(circle at 50% 30%, rgba(63, 111, 118, 0.35), transparent 70%);
+    filter: blur(16px);
+    opacity: 0.75;
+    pointer-events: none;
+    z-index: -2;
+}
+
+.avatar-hero > * {
+    position: relative;
+    z-index: 1;
+}
+
 .avatar-display {
     position: relative;
-    width: 150px;
-    height: 150px;
-    margin: 0 auto 18px;
-    padding: 6px;
+    width: min(72vw, 300px);
+    aspect-ratio: 1;
+    margin: 0 auto;
+    padding: 22px;
     border-radius: 50%;
-    background: linear-gradient(135deg, var(--color-accent), rgba(255, 255, 255, 0.9));
-    box-shadow: 0 16px 28px rgba(245, 178, 103, 0.25);
+    background:
+        radial-gradient(circle at 32% 28%, rgba(255, 255, 255, 0.92), rgba(249, 243, 234, 0.75) 58%, rgba(223, 232, 242, 0.65) 100%);
+    box-shadow:
+        0 26px 52px rgba(38, 68, 75, 0.28),
+        inset 0 18px 28px rgba(255, 255, 255, 0.35),
+        inset 0 -18px 34px rgba(63, 111, 118, 0.18);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    isolation: isolate;
+}
+
+.avatar-display::before {
+    content: "";
+    position: absolute;
+    inset: -18px;
+    border-radius: 50%;
+    background: linear-gradient(140deg, rgba(247, 178, 103, 0.46), rgba(63, 111, 118, 0.55));
+    filter: blur(0.4px);
+    z-index: -2;
+}
+
+.avatar-display::after {
+    content: "";
+    position: absolute;
+    inset: 18px;
+    border-radius: 50%;
+    background: radial-gradient(circle at 30% 24%, rgba(255, 255, 255, 0.75), transparent 68%);
+    z-index: -1;
 }
 
 .avatar-circle {
@@ -278,19 +354,30 @@ button:active {
     height: 100%;
     border-radius: 50%;
     object-fit: cover;
-    border: 4px solid rgba(255, 255, 255, 0.85);
-    box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.08);
+    border: 6px solid rgba(255, 255, 255, 0.82);
+    box-shadow: inset 0 0 22px rgba(38, 68, 75, 0.22);
+    background-color: rgba(223, 232, 242, 0.6);
+    transition: transform 0.45s ease, filter 0.45s ease;
+}
+
+.avatar-display:hover .avatar-circle {
+    transform: translateY(-3px) scale(1.01);
+    filter: saturate(1.05);
 }
 
 #webcam-feed {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 50%;
     background-color: rgba(223, 232, 242, 0.9);
 }
 
 #captured-photo {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    width: 100%;
+    height: 100%;
+    position: relative;
+    transform: none;
 }
 
 /* --- MODALS --- */

--- a/assets/avatars/ghibli-placeholder.svg
+++ b/assets/avatars/ghibli-placeholder.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="320" viewBox="0 0 320 320" role="img" aria-labelledby="title desc">
+  <title id="title">Sky Loft Guardian Placeholder</title>
+  <desc id="desc">A whimsical Ghibli-inspired avatar with mossy teal hair, warm lantern highlights, and floating sky blossoms.</desc>
+  <defs>
+    <radialGradient id="bgGlow" cx="50%" cy="42%" r="70%">
+      <stop offset="0%" stop-color="#fdfbf6"/>
+      <stop offset="55%" stop-color="#dfe8f2"/>
+      <stop offset="95%" stop-color="#3f6f76" stop-opacity="0.25"/>
+    </radialGradient>
+    <radialGradient id="bgAura" cx="20%" cy="20%" r="80%">
+      <stop offset="0%" stop-color="#f7e2ad" stop-opacity="0.85"/>
+      <stop offset="65%" stop-color="#f7e2ad" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="cloakGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3f6f76"/>
+      <stop offset="45%" stop-color="#4f8c92"/>
+      <stop offset="100%" stop-color="#26444b"/>
+    </linearGradient>
+    <linearGradient id="hairGradient" x1="15%" y1="0%" x2="80%" y2="100%">
+      <stop offset="0%" stop-color="#26444b"/>
+      <stop offset="45%" stop-color="#3f6f76"/>
+      <stop offset="100%" stop-color="#2c353a"/>
+    </linearGradient>
+    <radialGradient id="faceGlow" cx="48%" cy="35%" r="60%">
+      <stop offset="0%" stop-color="#fef9f0"/>
+      <stop offset="60%" stop-color="#f9f3ea"/>
+      <stop offset="100%" stop-color="#f7b267" stop-opacity="0.28"/>
+    </radialGradient>
+    <radialGradient id="cheekGradient" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#f7b267" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#f7b267" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="lanternLight" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#f7b267" stop-opacity="0.75"/>
+      <stop offset="100%" stop-color="#f7b267" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="trimGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f9f3ea"/>
+      <stop offset="100%" stop-color="#dfe8f2"/>
+    </linearGradient>
+    <filter id="softGlow" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="8" result="blur"/>
+      <feComposite in="blur" in2="SourceAlpha" operator="out" result="halo"/>
+      <feBlend in="SourceGraphic" in2="halo" mode="screen"/>
+    </filter>
+  </defs>
+  <rect width="320" height="320" fill="#dfe8f2"/>
+  <g transform="translate(16 16)">
+    <circle cx="144" cy="144" r="144" fill="url(#bgGlow)"/>
+    <circle cx="94" cy="86" r="88" fill="url(#bgAura)" opacity="0.55"/>
+    <circle cx="200" cy="210" r="78" fill="url(#lanternLight)" opacity="0.35"/>
+    <g filter="url(#softGlow)">
+      <ellipse cx="144" cy="270" rx="110" ry="30" fill="#26444b" fill-opacity="0.25"/>
+    </g>
+    <path d="M60 170c-12 36-8 86 84 90s110-44 90-88" fill="#2c353a" opacity="0.08"/>
+    <path d="M62 114c8-44 48-78 96-78s88 36 96 80c3 16 4 36-8 60-10-10-24-20-44-22-30-4-44 12-70 10-22-2-42-16-62-50z" fill="url(#hairGradient)"/>
+    <path d="M72 136c10-24 42-42 72-42s60 18 72 44c-6 12-26 28-44 30-14 2-21-6-28-6s-14 8-26 8c-20 0-40-16-46-34z" fill="#2c353a" opacity="0.28"/>
+    <ellipse cx="144" cy="170" rx="74" ry="82" fill="url(#faceGlow)"/>
+    <path d="M98 180c4 22 20 44 46 46 28 2 46-20 52-44-8 8-28 8-36 0-8 8-34 10-62-2z" fill="#f9f3ea" opacity="0.9"/>
+    <ellipse cx="118" cy="176" rx="16" ry="10" fill="url(#cheekGradient)"/>
+    <ellipse cx="174" cy="176" rx="16" ry="10" fill="url(#cheekGradient)"/>
+    <ellipse cx="126" cy="160" rx="12" ry="16" fill="#2c353a" opacity="0.85"/>
+    <ellipse cx="162" cy="160" rx="12" ry="16" fill="#2c353a" opacity="0.85"/>
+    <circle cx="124" cy="158" r="6" fill="#f9f3ea" opacity="0.9"/>
+    <circle cx="160" cy="158" r="6" fill="#f9f3ea" opacity="0.9"/>
+    <path d="M136 198c6 4 18 4 24 0-4 10-18 12-24 0z" fill="#f7b267" opacity="0.75"/>
+    <path d="M108 132c10-12 72-12 88 8-2-22-24-36-46-36s-36 12-42 28z" fill="#2c353a" opacity="0.45"/>
+    <path d="M84 220c22-16 44-24 60-24s42 8 64 26c10 8 32 36 0 58-18 12-56 16-92 6-38-12-48-38-32-66z" fill="url(#cloakGradient)"/>
+    <path d="M84 220c18 10 40 20 62 20s46-10 62-20c-6 28-22 54-62 54s-58-30-62-54z" fill="#26444b" opacity="0.35"/>
+    <path d="M102 214c14 10 28 14 42 14s26-4 42-14c-8-8-26-12-42-12s-34 4-42 12z" fill="url(#trimGradient)" opacity="0.75"/>
+    <path d="M58 132c-6 4-12 16-12 26 16 4 26 2 32-2-8-6-14-12-20-24z" fill="#3f6f76" opacity="0.75"/>
+    <path d="M226 134c4 8 10 20 24 26 0-14-6-26-10-30-4 0-10 2-14 4z" fill="#3f6f76" opacity="0.75"/>
+    <path d="M90 92c-12 0-22-12-22-22 14 0 30 6 42 22-6 0-12 0-20 0z" fill="#7fb27b" opacity="0.65"/>
+    <path d="M206 90c12-4 24-14 28-32-12 4-30 16-40 34 4-2 8-2 12-2z" fill="#7fb27b" opacity="0.6"/>
+    <g opacity="0.7">
+      <ellipse cx="72" cy="254" rx="22" ry="10" fill="#56646c" fill-opacity="0.45"/>
+      <ellipse cx="220" cy="256" rx="26" ry="12" fill="#56646c" fill-opacity="0.35"/>
+    </g>
+    <g opacity="0.6">
+      <path d="M40 166c-10 12-16 26-10 38 8 16 32 18 42 2-14-12-22-24-32-40z" fill="#7fb27b"/>
+      <path d="M242 164c12 18 18 32 8 46-10 14-32 12-40-6 12-10 22-18 32-40z" fill="#7fb27b"/>
+    </g>
+    <circle cx="90" cy="74" r="8" fill="#f9f3ea" opacity="0.85"/>
+    <circle cx="214" cy="70" r="10" fill="#f9f3ea" opacity="0.9"/>
+    <circle cx="66" cy="208" r="6" fill="#f7b267" opacity="0.8"/>
+    <circle cx="226" cy="208" r="6" fill="#f7b267" opacity="0.8"/>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,14 @@
     </div>
 
     <div id="app-screen" class="hidden">
+        <div class="avatar-hero">
+            <div class="avatar-display">
+                <video id="webcam-feed" class="avatar-circle hidden" autoplay playsinline></video>
+                <img id="captured-photo" class="avatar-circle" src="assets/avatars/ghibli-placeholder.svg" alt="Your Avatar">
+            </div>
+            <canvas id="photo-canvas" class="hidden"></canvas>
+        </div>
+
         <h2>Welcome to Your Codex</h2>
 
         <div id="level-xp-display" class="widget">
@@ -56,12 +64,7 @@
         </div>
 
         <div id="face-scan-section" class="widget">
-            <div class="avatar-display">
-                <video id="webcam-feed" class="avatar-circle hidden" autoplay playsinline></video>
-                <img id="captured-photo" class="avatar-circle" alt="Your Avatar">
-            </div>
-            <canvas id="photo-canvas" class="hidden"></canvas>
-            <button id="scan-face-btn">Create Avatar</button>
+            <button id="scan-face-btn">Scan Your Face &amp; Body</button>
         </div>
 
         <div id="dashboard" class="widget">

--- a/js/main.js
+++ b/js/main.js
@@ -37,6 +37,7 @@ const firebaseConfig = codexConfig.firebaseConfig;
 const BACKEND_SERVER_URL =
     typeof codexConfig.backendUrl === 'string' ? codexConfig.backendUrl.trim() : '';
 const AI_FEATURES_AVAILABLE = BACKEND_SERVER_URL.length > 0;
+const AVATAR_PLACEHOLDER_SRC = 'assets/avatars/ghibli-placeholder.svg';
 
 if (!firebaseConfig || typeof firebaseConfig !== 'object') {
     displayConfigurationError(
@@ -662,12 +663,17 @@ async function loadData(userId) {
         choreManager.chores = characterData.chores;
 
         const capturedPhoto = document.getElementById('captured-photo');
-        if (characterData.avatarUrl) {
-            capturedPhoto.src = characterData.avatarUrl;
+        const webcamFeed = document.getElementById('webcam-feed');
+        const scanButton = document.getElementById('scan-face-btn');
+        if (capturedPhoto) {
+            capturedPhoto.src = characterData.avatarUrl || AVATAR_PLACEHOLDER_SRC;
             capturedPhoto.classList.remove('hidden');
-        } else {
-            capturedPhoto.src = '';
-            capturedPhoto.classList.add('hidden');
+        }
+        if (webcamFeed) {
+            webcamFeed.classList.add('hidden');
+        }
+        if (scanButton) {
+            scanButton.textContent = characterData.avatarUrl ? 'Update Avatar' : 'Scan Your Face & Body';
         }
 
         syncSkillSearchInputWithTarget(characterData.skillSearchTarget);
@@ -881,8 +887,20 @@ async function handleFaceScan() {
         console.error('Avatar generation failed:', error);
         alert('Avatar generation failed. Try again later.');
     } finally {
-        scanButton.textContent = 'Rescan Face';
-        scanButton.disabled = false;
+        if (webcamFeed) {
+            webcamFeed.classList.add('hidden');
+            webcamFeed.srcObject = null;
+        }
+        if (capturedPhoto) {
+            if (!characterData.avatarUrl) {
+                capturedPhoto.src = AVATAR_PLACEHOLDER_SRC;
+            }
+            capturedPhoto.classList.remove('hidden');
+        }
+        if (scanButton) {
+            scanButton.textContent = characterData.avatarUrl ? 'Update Avatar' : 'Scan Your Face & Body';
+            scanButton.disabled = false;
+        }
     }
 }
 
@@ -928,14 +946,21 @@ function updateDashboard() {
     });
 
     const capturedPhoto = document.getElementById('captured-photo');
-    if (characterData.avatarUrl) {
-        capturedPhoto.src = characterData.avatarUrl;
+    const webcamFeed = document.getElementById('webcam-feed');
+    const scanButton = document.getElementById('scan-face-btn');
+    if (capturedPhoto) {
+        if (characterData.avatarUrl) {
+            capturedPhoto.src = characterData.avatarUrl;
+        } else {
+            capturedPhoto.src = AVATAR_PLACEHOLDER_SRC;
+        }
         capturedPhoto.classList.remove('hidden');
-        document.getElementById('webcam-feed').classList.add('hidden');
-        document.getElementById('scan-face-btn').textContent = 'Update Avatar';
-    } else {
-        capturedPhoto.src = '';
-        capturedPhoto.classList.add('hidden');
+    }
+    if (webcamFeed) {
+        webcamFeed.classList.add('hidden');
+    }
+    if (scanButton) {
+        scanButton.textContent = characterData.avatarUrl ? 'Update Avatar' : 'Scan Your Face & Body';
     }
 
     if (auth.currentUser) saveData();


### PR DESCRIPTION
## Summary
- add a whimsical Ghibli-inspired SVG avatar placeholder that uses the existing palette
- move the avatar into a new hero container, update the default image and scan button label, and expand the hero styling
- keep the placeholder visible until a scan succeeds and ensure scan-state labels stay in sync

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d1b986be248321881a2d0238ad2a7c