### PR TITLE
Reorder welcome header and xp widget

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -115,6 +115,10 @@ p {
     border: 1px solid rgba(255, 255, 255, 0.7);
 }
 
+#app-screen > h2 {
+    margin: 0;
+}
+
 /* --- FORM CONTROLS --- */
 input,
 select,
@@ -264,7 +268,7 @@ button:active {
 /* --- FACE SCAN & AVATAR --- */
 .avatar-hero {
     position: relative;
-    margin: -14px -10px 6px;
+    margin: 0 -10px 6px;
     padding: 38px 28px 48px;
     border-radius: 42px;
     background:

--- a/index.html
+++ b/index.html
@@ -17,14 +17,6 @@
     </div>
 
     <div id="app-screen" class="hidden">
-        <div class="avatar-hero">
-            <div class="avatar-display">
-                <video id="webcam-feed" class="avatar-circle hidden" autoplay playsinline></video>
-                <img id="captured-photo" class="avatar-circle" src="assets/avatars/ghibli-placeholder.svg" alt="Your Avatar">
-            </div>
-            <canvas id="photo-canvas" class="hidden"></canvas>
-        </div>
-
         <h2>Welcome to Your Codex</h2>
 
         <div id="level-xp-display" class="widget">
@@ -35,6 +27,14 @@
             <div class="progress-bar-container">
                 <div id="xp-bar" class="progress-bar"></div>
             </div>
+        </div>
+
+        <div class="avatar-hero">
+            <div class="avatar-display">
+                <video id="webcam-feed" class="avatar-circle hidden" autoplay playsinline></video>
+                <img id="captured-photo" class="avatar-circle" src="assets/avatars/ghibli-placeholder.svg" alt="Your Avatar">
+            </div>
+            <canvas id="photo-canvas" class="hidden"></canvas>
         </div>
         
         <div id="perk-point-display" class="widget">


### PR DESCRIPTION
## Summary
- move the welcome heading and level/xp widget ahead of the avatar hero block in the dashboard
- tweak layout styling so the reordered elements keep consistent spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1c0d0ca8c832191b52ac539745c3e