### PR TITLE
Replace avatar placeholder PNG with SVG

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -382,6 +382,14 @@ button:active {
     height: 100%;
     position: relative;
     transform: none;
+    padding: 0;
+}
+
+#captured-photo.avatar-placeholder {
+    object-fit: contain;
+    padding: 6%;
+    background: transparent;
+    object-position: bottom center;
 }
 
 /* --- MODALS --- */

--- a/assets/avatars/heroic-white-male-placeholder.svg
+++ b/assets/avatars/heroic-white-male-placeholder.svg
@@ -1,0 +1,71 @@
+<svg width="320" height="480" viewBox="0 0 320 480" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Stylized heroic avatar placeholder</title>
+  <desc id="desc">Illustration of a heroic adventurer standing confidently with a cape in a circular vignette.</desc>
+  <defs>
+    <linearGradient id="skyGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f9f5ec" />
+      <stop offset="35%" stop-color="#e6f1f4" />
+      <stop offset="100%" stop-color="#cfdce4" />
+    </linearGradient>
+    <radialGradient id="glowGradient" cx="0.5" cy="0.2" r="0.65">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.9)" />
+      <stop offset="55%" stop-color="rgba(255,255,255,0.35)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </radialGradient>
+    <linearGradient id="capeGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#b03f50" />
+      <stop offset="100%" stop-color="#772c5a" />
+    </linearGradient>
+    <linearGradient id="armorGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#4f6f8a" />
+      <stop offset="55%" stop-color="#385264" />
+      <stop offset="100%" stop-color="#2b3c4b" />
+    </linearGradient>
+    <linearGradient id="accentGradient" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#f7b267" />
+      <stop offset="100%" stop-color="#f29e5b" />
+    </linearGradient>
+    <linearGradient id="trouserGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#263645" />
+      <stop offset="100%" stop-color="#111c28" />
+    </linearGradient>
+    <linearGradient id="bootGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2d1f17" />
+      <stop offset="100%" stop-color="#1c130f" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="480" fill="url(#skyGradient)" />
+  <circle cx="160" cy="110" r="150" fill="url(#glowGradient)" />
+  <ellipse cx="160" cy="400" rx="120" ry="42" fill="rgba(63,111,118,0.18)" />
+  <ellipse cx="160" cy="388" rx="132" ry="56" fill="rgba(63,111,118,0.25)" />
+  <g transform="translate(160,360)">
+    <path d="M-98-140 C-120-220 -60-250 0-260 C60-250 110-220 92-150 C72-90 22-40 -10-30" fill="rgba(63,111,118,0.1)" />
+  </g>
+  <g transform="translate(160 150)">
+    <path d="M-120 120 C-98 40 -70 -10 -32 -18 L-30 72 Z" fill="url(#capeGradient)" opacity="0.92" />
+    <path d="M120 120 C98 42 70 -4 28 -18 L32 70 Z" fill="url(#capeGradient)" opacity="0.88" />
+    <path d="M-18 -16 L18 -16 L28 120 L-28 120 Z" fill="url(#armorGradient)" />
+    <path d="M-18 14 H18 L22 76 H-22 Z" fill="#2a3f50" opacity="0.55" />
+    <rect x="-22" y="24" width="44" height="16" rx="8" fill="url(#accentGradient)" />
+    <path d="M-34 -12 C-54 32 -58 90 -44 148 L-18 148 L-8 20 Z" fill="#2f4657" />
+    <path d="M34 -12 C54 32 58 90 44 148 L18 148 L8 20 Z" fill="#2f4657" />
+    <path d="M-18 120 H18 L12 210 L-12 210 Z" fill="url(#trouserGradient)" />
+    <path d="M-44 150 C-40 110 -36 80 -26 16 L-2 18 L-14 150 Z" fill="url(#trouserGradient)" opacity="0.94" />
+    <path d="M44 150 C40 110 36 80 26 16 L2 18 L14 150 Z" fill="url(#trouserGradient)" opacity="0.94" />
+    <path d="M-40 210 H-4 L-6 248 L-52 248 Z" fill="url(#bootGradient)" />
+    <path d="M40 210 H4 L6 248 L52 248 Z" fill="url(#bootGradient)" />
+    <circle cx="0" cy="-58" r="32" fill="#f5d7c6" />
+    <path d="M-18 -76 Q0 -96 18 -76" fill="#e5c1ab" />
+    <path d="M-10 -50 Q0 -42 10 -50" stroke="#d49c8b" stroke-width="4" stroke-linecap="round" fill="none" />
+    <path d="M-18 -20 C-28 10 -30 40 -24 58 L-10 58 Z" fill="#f5d7c6" />
+    <path d="M18 -20 C28 10 30 40 24 58 L10 58 Z" fill="#f5d7c6" />
+    <path d="M-28 -100 C-8 -128 8 -128 28 -100 Q32 -72 20 -60 C12 -90 -12 -90 -20 -60 Q-32 -72 -28 -100 Z" fill="#4c3d34" />
+    <circle cx="-10" cy="-62" r="4" fill="#2b1f19" />
+    <circle cx="10" cy="-62" r="4" fill="#2b1f19" />
+    <path d="M-12 -44 Q0 -34 12 -44" stroke="#b27d6b" stroke-width="4" stroke-linecap="round" fill="none" />
+    <path d="M-44 36 L-90 48 L-96 32 L-54 14 Z" fill="#f7d6b8" opacity="0.9" />
+    <circle cx="-94" cy="34" r="14" fill="#f7b267" />
+    <path d="M44 36 L90 48 L96 32 L54 14 Z" fill="#f4ceb0" opacity="0.9" />
+    <circle cx="94" cy="34" r="14" fill="#f29e5b" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
         <div class="avatar-hero">
             <div class="avatar-display">
                 <video id="webcam-feed" class="avatar-circle hidden" autoplay playsinline></video>
-                <img id="captured-photo" class="avatar-circle" src="assets/avatars/ghibli-placeholder.svg" alt="Your Avatar">
+                <img id="captured-photo" class="avatar-circle avatar-placeholder" src="assets/avatars/heroic-white-male-placeholder.svg" alt="Your Avatar">
             </div>
             <canvas id="photo-canvas" class="hidden"></canvas>
         </div>

--- a/js/main.js
+++ b/js/main.js
@@ -37,7 +37,7 @@ const firebaseConfig = codexConfig.firebaseConfig;
 const BACKEND_SERVER_URL =
     typeof codexConfig.backendUrl === 'string' ? codexConfig.backendUrl.trim() : '';
 const AI_FEATURES_AVAILABLE = BACKEND_SERVER_URL.length > 0;
-const AVATAR_PLACEHOLDER_SRC = 'assets/avatars/ghibli-placeholder.svg';
+const AVATAR_PLACEHOLDER_SRC = 'assets/avatars/heroic-white-male-placeholder.svg';
 
 if (!firebaseConfig || typeof firebaseConfig !== 'object') {
     displayConfigurationError(
@@ -81,6 +81,22 @@ const skillSearchInput = document.getElementById('skill-search-input');
 const skillTreePanControls = document.getElementById('skill-tree-pan-controls');
 const skillPanLeftBtn = document.getElementById('skill-pan-left');
 const skillPanRightBtn = document.getElementById('skill-pan-right');
+
+function updateCapturedPhotoElement(element, imageSrc) {
+    if (!element) {
+        return;
+    }
+
+    const trimmedSrc = typeof imageSrc === 'string' ? imageSrc.trim() : '';
+    const resolvedSrc = trimmedSrc && trimmedSrc !== AVATAR_PLACEHOLDER_SRC
+        ? trimmedSrc
+        : AVATAR_PLACEHOLDER_SRC;
+
+    element.src = resolvedSrc;
+    const isPlaceholder = resolvedSrc === AVATAR_PLACEHOLDER_SRC;
+    element.classList.toggle('avatar-placeholder', isPlaceholder);
+    element.classList.remove('hidden');
+}
 
 const skillTreeUtils = window.SkillTreeUtils || {};
 const resolveConstellationStarsMap = typeof skillTreeUtils.getConstellationStarsMap === 'function'
@@ -665,10 +681,7 @@ async function loadData(userId) {
         const capturedPhoto = document.getElementById('captured-photo');
         const webcamFeed = document.getElementById('webcam-feed');
         const scanButton = document.getElementById('scan-face-btn');
-        if (capturedPhoto) {
-            capturedPhoto.src = characterData.avatarUrl || AVATAR_PLACEHOLDER_SRC;
-            capturedPhoto.classList.remove('hidden');
-        }
+        updateCapturedPhotoElement(capturedPhoto, characterData.avatarUrl);
         if (webcamFeed) {
             webcamFeed.classList.add('hidden');
         }
@@ -891,12 +904,7 @@ async function handleFaceScan() {
             webcamFeed.classList.add('hidden');
             webcamFeed.srcObject = null;
         }
-        if (capturedPhoto) {
-            if (!characterData.avatarUrl) {
-                capturedPhoto.src = AVATAR_PLACEHOLDER_SRC;
-            }
-            capturedPhoto.classList.remove('hidden');
-        }
+        updateCapturedPhotoElement(capturedPhoto, characterData.avatarUrl);
         if (scanButton) {
             scanButton.textContent = characterData.avatarUrl ? 'Update Avatar' : 'Scan Your Face & Body';
             scanButton.disabled = false;
@@ -948,14 +956,7 @@ function updateDashboard() {
     const capturedPhoto = document.getElementById('captured-photo');
     const webcamFeed = document.getElementById('webcam-feed');
     const scanButton = document.getElementById('scan-face-btn');
-    if (capturedPhoto) {
-        if (characterData.avatarUrl) {
-            capturedPhoto.src = characterData.avatarUrl;
-        } else {
-            capturedPhoto.src = AVATAR_PLACEHOLDER_SRC;
-        }
-        capturedPhoto.classList.remove('hidden');
-    }
+    updateCapturedPhotoElement(capturedPhoto, characterData.avatarUrl);
     if (webcamFeed) {
         webcamFeed.classList.add('hidden');
     }


### PR DESCRIPTION
## Summary
- replace the binary PNG avatar placeholder with a stylized SVG illustration to avoid unsupported binary assets
- point the dashboard avatar markup and JavaScript placeholder constant to the SVG file
- tweak the avatar placeholder styling so the vector art fits cleanly inside the circular frame

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d1c2412a448321a8e8747254b0f5b1