### PR TITLE
Replace Three.js stubs with offline renderer implementation

### DIFF
--- a/js/vendor/OrbitControls.js
+++ b/js/vendor/OrbitControls.js
@@ -1,76 +1,248 @@
 (function(global){
+    'use strict';
+
     const scope = global || (typeof window !== 'undefined' ? window : this);
     const THREE = scope && scope.THREE;
-    if(!THREE){
+    if (!THREE) {
         throw new Error('OrbitControls requires THREE to be available on the global scope.');
     }
-    if(THREE.OrbitControls && THREE.OrbitControls.__CODEx_STUB__){
-        return;
-    }
+
+    const STATE = {
+        NONE: -1,
+        ROTATE: 0,
+        PAN: 1
+    };
 
     class OrbitControls extends THREE.EventDispatcher {
-        constructor(object, domElement){
+        constructor(object, domElement) {
             super();
+            if (!object) {
+                throw new Error('OrbitControls requires a camera object.');
+            }
             this.object = object;
             this.domElement = domElement || (scope.document && scope.document.body) || null;
+            if (!this.domElement) {
+                throw new Error('OrbitControls requires a DOM element.');
+            }
 
             this.enabled = true;
             this.enableDamping = false;
             this.dampingFactor = 0.05;
+            this.enableZoom = true;
+            this.zoomSpeed = 1.0;
+            this.enableRotate = true;
+            this.rotateSpeed = 0.8;
+            this.enablePan = true;
+            this.panSpeed = 1.0;
             this.screenSpacePanning = true;
             this.minDistance = 0;
             this.maxDistance = Infinity;
-            this.enablePan = true;
-            this.enableZoom = true;
-            this.enableRotate = true;
+            this.minPolarAngle = 0;
+            this.maxPolarAngle = Math.PI;
+            this.minAzimuthAngle = -Infinity;
+            this.maxAzimuthAngle = Infinity;
+
             this.target = new THREE.Vector3();
 
-            this._onPointerDown = () => {
-                if(!this.enabled){
-                    return;
-                }
-                this.dispatchEvent({ type: 'start' });
-            };
+            this._state = STATE.NONE;
+            this._spherical = new THREE.Spherical();
+            this._sphericalDelta = new THREE.Spherical(0, 0, 0);
+            this._scale = 1;
+            this._panOffset = new THREE.Vector3();
+            this._lastPosition = new THREE.Vector3();
+            this._lastTarget = new THREE.Vector3();
+            this._pointer = new THREE.Vector2();
+            this._startPointer = new THREE.Vector2();
 
-            this._onPointerUp = () => {
-                if(!this.enabled){
-                    return;
-                }
-                this.dispatchEvent({ type: 'end' });
-            };
+            this._onContextMenu = this._onContextMenu.bind(this);
+            this._onMouseDown = this._onMouseDown.bind(this);
+            this._onMouseMove = this._onMouseMove.bind(this);
+            this._onMouseUp = this._onMouseUp.bind(this);
+            this._onMouseWheel = this._onMouseWheel.bind(this);
 
-            this._onPointerMove = () => {
-                if(!this.enabled){
-                    return;
-                }
-                this.dispatchEvent({ type: 'change' });
-            };
+            this.domElement.style.touchAction = this.domElement.style.touchAction || 'none';
+            this.domElement.addEventListener('contextmenu', this._onContextMenu);
+            this.domElement.addEventListener('mousedown', this._onMouseDown);
+            this.domElement.addEventListener('wheel', this._onMouseWheel, { passive: false });
+        }
 
-            if(this.domElement && this.domElement.addEventListener){
-                this.domElement.addEventListener('pointerdown', this._onPointerDown);
-                this.domElement.addEventListener('pointerup', this._onPointerUp);
-                this.domElement.addEventListener('pointermove', this._onPointerMove);
+        dispose() {
+            if (!this.domElement) {
+                return;
+            }
+            this.domElement.removeEventListener('contextmenu', this._onContextMenu);
+            this.domElement.removeEventListener('mousedown', this._onMouseDown);
+            this.domElement.removeEventListener('wheel', this._onMouseWheel);
+            const doc = this.domElement.ownerDocument || scope.document;
+            if (doc) {
+                doc.removeEventListener('mousemove', this._onMouseMove);
+                doc.removeEventListener('mouseup', this._onMouseUp);
             }
         }
 
-        update(){
-            if(!this.enabled){
+        _onContextMenu(event) {
+            event.preventDefault();
+        }
+
+        _onMouseDown(event) {
+            if (!this.enabled) {
+                return;
+            }
+            event.preventDefault();
+            if (event.button === 0) {
+                this._state = event.shiftKey ? STATE.PAN : STATE.ROTATE;
+            } else if (event.button === 2) {
+                this._state = STATE.PAN;
+            } else {
+                return;
+            }
+            this._startPointer.set(event.clientX, event.clientY);
+            const doc = this.domElement.ownerDocument || scope.document;
+            if (doc) {
+                doc.addEventListener('mousemove', this._onMouseMove);
+                doc.addEventListener('mouseup', this._onMouseUp);
+            }
+            this.dispatchEvent({ type: 'start' });
+        }
+
+        _onMouseMove(event) {
+            if (!this.enabled || this._state === STATE.NONE) {
+                return;
+            }
+            event.preventDefault();
+            this._pointer.set(event.clientX, event.clientY);
+            const deltaX = this._pointer.x - this._startPointer.x;
+            const deltaY = this._pointer.y - this._startPointer.y;
+            if (this._state === STATE.ROTATE && this.enableRotate) {
+                this._handleRotate(deltaX, deltaY);
+            } else if (this._state === STATE.PAN && this.enablePan) {
+                this._handlePan(deltaX, deltaY);
+            }
+            this._startPointer.copy(this._pointer);
+            this.dispatchEvent({ type: 'change' });
+        }
+
+        _onMouseUp(event) {
+            event.preventDefault();
+            this._state = STATE.NONE;
+            const doc = this.domElement.ownerDocument || scope.document;
+            if (doc) {
+                doc.removeEventListener('mousemove', this._onMouseMove);
+                doc.removeEventListener('mouseup', this._onMouseUp);
+            }
+            this.dispatchEvent({ type: 'end' });
+        }
+
+        _onMouseWheel(event) {
+            if (!this.enabled || !this.enableZoom) {
+                return;
+            }
+            event.preventDefault();
+            const delta = event.deltaY;
+            if (delta > 0) {
+                this._dollyIn(Math.pow(0.95, this.zoomSpeed));
+            } else if (delta < 0) {
+                this._dollyOut(Math.pow(0.95, this.zoomSpeed));
+            }
+            this.dispatchEvent({ type: 'change' });
+        }
+
+        _handleRotate(deltaX, deltaY) {
+            const element = this.domElement;
+            const rotateDeltaTheta = (2 * Math.PI * deltaX / element.clientHeight) * this.rotateSpeed;
+            const rotateDeltaPhi = (2 * Math.PI * deltaY / element.clientHeight) * this.rotateSpeed;
+            this._sphericalDelta.theta -= rotateDeltaTheta;
+            this._sphericalDelta.phi -= rotateDeltaPhi;
+        }
+
+        _handlePan(deltaX, deltaY) {
+            const element = this.domElement;
+            const offset = this.object.position.clone().sub(this.target);
+            const targetDistance = offset.length();
+            const fov = this.object.fov || 50;
+            const distance = targetDistance * Math.tan((fov * Math.PI / 180) / 2);
+            const panX = (2 * deltaX * distance / element.clientHeight) * this.panSpeed;
+            const panY = (2 * deltaY * distance / element.clientHeight) * this.panSpeed;
+            const forward = offset.clone().normalize().negate();
+            const right = forward.clone().cross(this.object.up).normalize();
+            if (right.lengthSq() === 0) {
+                right.set(1, 0, 0);
+            }
+            if (this.screenSpacePanning) {
+                this._panOffset.addScaledVector(right, -panX);
+                const up = this.object.up.clone().normalize();
+                this._panOffset.addScaledVector(up, panY);
+            } else {
+                const up = right.clone().cross(forward).normalize();
+                this._panOffset.addScaledVector(right, -panX);
+                this._panOffset.addScaledVector(up, panY);
+            }
+        }
+
+        _dollyIn(scale) {
+            this._scale /= scale;
+        }
+
+        _dollyOut(scale) {
+            this._scale *= scale;
+        }
+
+        update() {
+            this.object.__controlTarget = this.target;
+            if (!this.enabled) {
+                this._sphericalDelta.theta = 0;
+                this._sphericalDelta.phi = 0;
+                this._panOffset.set(0, 0, 0);
+                this._scale = 1;
                 return false;
+            }
+            const offset = this.object.position.clone().sub(this.target);
+            this._spherical.setFromVector3(offset);
+
+            this._spherical.theta += this._sphericalDelta.theta;
+            this._spherical.phi += this._sphericalDelta.phi;
+            this._spherical.makeSafe();
+
+            this._spherical.theta = THREE.MathUtils.clamp(this._spherical.theta, this.minAzimuthAngle, this.maxAzimuthAngle);
+            this._spherical.phi = THREE.MathUtils.clamp(this._spherical.phi, this.minPolarAngle, this.maxPolarAngle);
+
+            this._spherical.radius *= this._scale;
+            this._spherical.radius = THREE.MathUtils.clamp(this._spherical.radius, this.minDistance, this.maxDistance);
+
+            this.target.add(this._panOffset);
+
+            const sinPhiRadius = Math.sin(this._spherical.phi) * this._spherical.radius;
+            const cosPhiRadius = Math.cos(this._spherical.phi) * this._spherical.radius;
+
+            this.object.position.set(
+                this.target.x + sinPhiRadius * Math.sin(this._spherical.theta),
+                this.target.y + cosPhiRadius,
+                this.target.z + sinPhiRadius * Math.cos(this._spherical.theta)
+            );
+
+            this.object.__controlTarget = this.target;
+
+            if (this.enableDamping) {
+                this._sphericalDelta.theta *= (1 - this.dampingFactor);
+                this._sphericalDelta.phi *= (1 - this.dampingFactor);
+                this._panOffset.multiplyScalar(1 - this.dampingFactor);
+            } else {
+                this._sphericalDelta.theta = 0;
+                this._sphericalDelta.phi = 0;
+                this._panOffset.set(0, 0, 0);
+            }
+            this._scale = 1;
+
+            const positionChanged = this._lastPosition.distanceToSquared(this.object.position) > 1e-7;
+            const targetChanged = this._lastTarget.distanceToSquared(this.target) > 1e-7;
+            if (positionChanged || targetChanged) {
+                this._lastPosition.copy(this.object.position);
+                this._lastTarget.copy(this.target);
+                return true;
             }
             return false;
         }
-
-        dispose(){
-            if(this.domElement && this.domElement.removeEventListener){
-                this.domElement.removeEventListener('pointerdown', this._onPointerDown);
-                this.domElement.removeEventListener('pointerup', this._onPointerUp);
-                this.domElement.removeEventListener('pointermove', this._onPointerMove);
-            }
-            this.dispatchEvent({ type: 'dispose' });
-        }
     }
-
-    OrbitControls.__CODEx_STUB__ = true;
 
     THREE.OrbitControls = OrbitControls;
 })(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));

--- a/js/vendor/three.min.js
+++ b/js/vendor/three.min.js
@@ -1,441 +1,484 @@
 (function(global){
-    if(!global) {
-        throw new Error('Global scope is required for Three.js stub.');
+    'use strict';
+
+    if (!global) {
+        throw new Error('Global scope is required for Three.js replacement.');
     }
-    if(global.THREE && global.THREE.__CODEx_STUB__) {
+
+    if (global.THREE && global.THREE.__CODEx_CUSTOM__) {
         return;
     }
+
     const THREE = {};
+    THREE.__CODEx_CUSTOM__ = true;
+    THREE.REVISION = 'CV-lite-1';
 
-    function isNumber(value){
-        return typeof value === 'number' && isFinite(value);
-    }
+    const DEG2RAD = Math.PI / 180;
+    const RAD2DEG = 180 / Math.PI;
 
-    class EventDispatcher {
-        constructor(){
-            this._listeners = {};
+    THREE.MathUtils = {
+        DEG2RAD,
+        RAD2DEG,
+        clamp(value, min, max) {
+            return Math.max(min, Math.min(max, value));
+        },
+        lerp(start, end, alpha) {
+            return start + (end - start) * alpha;
         }
-        addEventListener(type, listener){
-            if(typeof listener !== 'function'){
-                return;
-            }
-            if(!this._listeners[type]){
-                this._listeners[type] = [];
-            }
-            if(this._listeners[type].indexOf(listener) === -1){
-                this._listeners[type].push(listener);
-            }
+    };
+
+    class Vector2 {
+        constructor(x = 0, y = 0) {
+            this.x = x;
+            this.y = y;
         }
-        removeEventListener(type, listener){
-            const listeners = this._listeners[type];
-            if(!listeners){
-                return;
-            }
-            const index = listeners.indexOf(listener);
-            if(index !== -1){
-                listeners.splice(index, 1);
-            }
+        set(x, y) {
+            this.x = x;
+            this.y = y;
+            return this;
         }
-        dispatchEvent(event){
-            if(!event || !event.type){
-                return;
-            }
-            const listeners = this._listeners[event.type];
-            if(!listeners || listeners.length === 0){
-                return;
-            }
-            const array = listeners.slice();
-            for(let i=0;i<array.length;i++){
-                try {
-                    array[i].call(this, event);
-                } catch(err){
-                    setTimeout(()=>{ throw err; });
-                }
-            }
+        copy(v) {
+            this.x = v.x;
+            this.y = v.y;
+            return this;
+        }
+        clone() {
+            return new Vector2(this.x, this.y);
+        }
+        subVectors(a, b) {
+            this.x = a.x - b.x;
+            this.y = a.y - b.y;
+            return this;
         }
     }
 
     class Vector3 {
-        constructor(x=0, y=0, z=0){
+        constructor(x = 0, y = 0, z = 0) {
             this.x = x;
             this.y = y;
             this.z = z;
         }
-        set(x, y, z){
+        set(x, y, z) {
             this.x = x;
             this.y = y;
             this.z = z;
             return this;
         }
-        copy(v){
-            if(v){
-                this.x = v.x;
-                this.y = v.y;
-                this.z = v.z;
-            }
+        copy(v) {
+            this.x = v.x;
+            this.y = v.y;
+            this.z = v.z;
             return this;
         }
-        clone(){
+        clone() {
             return new Vector3(this.x, this.y, this.z);
         }
-        add(v){
+        add(v) {
             this.x += v.x;
             this.y += v.y;
             this.z += v.z;
             return this;
         }
-        sub(v){
-            this.x -= v.x;
-            this.y -= v.y;
-            this.z -= v.z;
-            return this;
-        }
-        subVectors(a, b){
-            this.x = a.x - b.x;
-            this.y = a.y - b.y;
-            this.z = a.z - b.z;
-            return this;
-        }
-        multiplyScalar(s){
-            this.x *= s;
-            this.y *= s;
-            this.z *= s;
-            return this;
-        }
-        length(){
-            return Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z);
-        }
-        normalize(){
-            const len = this.length();
-            if(len > 0){
-                this.multiplyScalar(1 / len);
-            }
-            return this;
-        }
-        distanceTo(v){
-            const dx = this.x - v.x;
-            const dy = this.y - v.y;
-            const dz = this.z - v.z;
-            return Math.sqrt(dx * dx + dy * dy + dz * dz);
-        }
-        negate(){
-            this.x = -this.x;
-            this.y = -this.y;
-            this.z = -this.z;
-            return this;
-        }
-        addScalar(s){
+        addScalar(s) {
             this.x += s;
             this.y += s;
             this.z += s;
             return this;
         }
-        addVectors(a, b){
-            this.x = a.x + b.x;
-            this.y = a.y + b.y;
-            this.z = a.z + b.z;
+        addScaledVector(v, s) {
+            this.x += v.x * s;
+            this.y += v.y * s;
+            this.z += v.z * s;
             return this;
         }
-        lerp(v, alpha){
+        sub(v) {
+            this.x -= v.x;
+            this.y -= v.y;
+            this.z -= v.z;
+            return this;
+        }
+        subVectors(a, b) {
+            this.x = a.x - b.x;
+            this.y = a.y - b.y;
+            this.z = a.z - b.z;
+            return this;
+        }
+        multiplyScalar(s) {
+            this.x *= s;
+            this.y *= s;
+            this.z *= s;
+            return this;
+        }
+        multiply(v) {
+            this.x *= v.x;
+            this.y *= v.y;
+            this.z *= v.z;
+            return this;
+        }
+        divideScalar(s) {
+            if (s !== 0) {
+                const inv = 1 / s;
+                this.x *= inv;
+                this.y *= inv;
+                this.z *= inv;
+            } else {
+                this.x = 0;
+                this.y = 0;
+                this.z = 0;
+            }
+            return this;
+        }
+        length() {
+            return Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z);
+        }
+        lengthSq() {
+            return this.x * this.x + this.y * this.y + this.z * this.z;
+        }
+        normalize() {
+            const len = this.length();
+            if (len > 0) {
+                this.divideScalar(len);
+            }
+            return this;
+        }
+        distanceTo(v) {
+            return Math.sqrt(this.distanceToSquared(v));
+        }
+        distanceToSquared(v) {
+            const dx = this.x - v.x;
+            const dy = this.y - v.y;
+            const dz = this.z - v.z;
+            return dx * dx + dy * dy + dz * dz;
+        }
+        dot(v) {
+            return this.x * v.x + this.y * v.y + this.z * v.z;
+        }
+        cross(v) {
+            const x = this.y * v.z - this.z * v.y;
+            const y = this.z * v.x - this.x * v.z;
+            const z = this.x * v.y - this.y * v.x;
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            return this;
+        }
+        crossVectors(a, b) {
+            const x = a.y * b.z - a.z * b.y;
+            const y = a.z * b.x - a.x * b.z;
+            const z = a.x * b.y - a.y * b.x;
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            return this;
+        }
+        negate() {
+            this.x = -this.x;
+            this.y = -this.y;
+            this.z = -this.z;
+            return this;
+        }
+        lerp(v, alpha) {
             this.x += (v.x - this.x) * alpha;
             this.y += (v.y - this.y) * alpha;
             this.z += (v.z - this.z) * alpha;
             return this;
         }
-    }
-
-    class Vector2 {
-        constructor(x=0, y=0){
-            this.x = x;
-            this.y = y;
-        }
-        set(x, y){
-            this.x = x;
-            this.y = y;
-            return this;
-        }
-        copy(v){
-            if(v){
-                this.x = v.x;
-                this.y = v.y;
+        setLength(length) {
+            const oldLength = this.length();
+            if (oldLength !== 0 && length !== oldLength) {
+                this.multiplyScalar(length / oldLength);
             }
             return this;
-        }
-        clone(){
-            return new Vector2(this.x, this.y);
-        }
-    }
-
-    class Euler {
-        constructor(x=0, y=0, z=0){
-            this.x = x;
-            this.y = y;
-            this.z = z;
-        }
-        set(x, y, z){
-            this.x = x;
-            this.y = y;
-            this.z = z;
-            return this;
-        }
-        copy(euler){
-            if(euler){
-                this.x = euler.x;
-                this.y = euler.y;
-                this.z = euler.z;
-            }
-            return this;
-        }
-        clone(){
-            return new Euler(this.x, this.y, this.z);
         }
     }
 
     class Color {
-        constructor(hex=0xffffff){
-            this.setHex(hex);
+        constructor(value = 0xffffff) {
+            this.setHex(value);
         }
-        set(hex){
-            if(hex instanceof Color){
-                this.r = hex.r;
-                this.g = hex.g;
-                this.b = hex.b;
-            } else if(typeof hex === 'number'){
-                this.setHex(hex);
-            }
-            return this;
-        }
-        setHex(hex){
-            const value = isNumber(hex) ? hex : 0xffffff;
+        setHex(hex) {
+            const value = (typeof hex === 'number') ? hex : parseInt(hex.replace('#', ''), 16);
             this.r = ((value >> 16) & 255) / 255;
             this.g = ((value >> 8) & 255) / 255;
             this.b = (value & 255) / 255;
             return this;
         }
-        copy(color){
-            if(color){
-                this.r = color.r;
-                this.g = color.g;
-                this.b = color.b;
-            }
+        copy(color) {
+            this.r = color.r;
+            this.g = color.g;
+            this.b = color.b;
             return this;
         }
-        clone(){
+        clone() {
             const c = new Color();
             c.r = this.r;
             c.g = this.g;
             c.b = this.b;
             return c;
         }
+        add(color) {
+            this.r += color.r;
+            this.g += color.g;
+            this.b += color.b;
+            return this;
+        }
+        multiplyScalar(s) {
+            this.r *= s;
+            this.g *= s;
+            this.b *= s;
+            return this;
+        }
+        getStyle(alpha = 1) {
+            const r = Math.round(THREE.MathUtils.clamp(this.r, 0, 1) * 255);
+            const g = Math.round(THREE.MathUtils.clamp(this.g, 0, 1) * 255);
+            const b = Math.round(THREE.MathUtils.clamp(this.b, 0, 1) * 255);
+            return `rgba(${r}, ${g}, ${b}, ${THREE.MathUtils.clamp(alpha, 0, 1)})`;
+        }
+    }
+
+    class EventDispatcher {
+        constructor() {
+            this._listeners = {};
+        }
+        addEventListener(type, listener) {
+            if (typeof listener !== 'function') {
+                return;
+            }
+            if (!this._listeners[type]) {
+                this._listeners[type] = [];
+            }
+            if (this._listeners[type].indexOf(listener) === -1) {
+                this._listeners[type].push(listener);
+            }
+        }
+        removeEventListener(type, listener) {
+            const listeners = this._listeners[type];
+            if (!listeners) {
+                return;
+            }
+            const index = listeners.indexOf(listener);
+            if (index !== -1) {
+                listeners.splice(index, 1);
+            }
+        }
+        dispatchEvent(event) {
+            if (!event || typeof event.type !== 'string') {
+                return;
+            }
+            const listeners = this._listeners[event.type];
+            if (!listeners || !listeners.length) {
+                return;
+            }
+            listeners.slice().forEach(listener => listener.call(this, event));
+        }
     }
 
     class Object3D extends EventDispatcher {
-        constructor(){
+        constructor() {
             super();
-            this.children = [];
-            this.parent = null;
-            this.position = new Vector3();
-            this.rotation = new Euler();
-            this.scale = new Vector3(1, 1, 1);
-            this.userData = {};
             this.name = '';
+            this.parent = null;
+            this.children = [];
+            this.position = new Vector3();
+            this.scale = new Vector3(1, 1, 1);
+            this.rotation = new Vector3();
+            this.visible = true;
+            this.userData = {};
+            this.renderOrder = 0;
+            this.matrixWorldNeedsUpdate = true;
         }
-        add(object){
-            if(!object || object === this){
+        add(object) {
+            if (!object || object === this) {
                 return;
             }
-            if(object.parent){
+            if (object.parent) {
                 object.parent.remove(object);
             }
             object.parent = this;
             this.children.push(object);
+            this.matrixWorldNeedsUpdate = true;
         }
-        remove(object){
+        remove(object) {
             const index = this.children.indexOf(object);
-            if(index !== -1){
-                this.children.splice(index, 1);
+            if (index !== -1) {
                 object.parent = null;
+                this.children.splice(index, 1);
+                this.matrixWorldNeedsUpdate = true;
             }
         }
-        traverse(callback){
+        traverse(callback) {
             callback(this);
-            for(let i=0;i<this.children.length;i++){
-                this.children[i].traverse(callback);
+            this.children.forEach(child => child.traverse(callback));
+        }
+        getWorldPosition(target = new Vector3()) {
+            target.copy(this.position);
+            let parent = this.parent;
+            while (parent) {
+                target.add(parent.position);
+                parent = parent.parent;
             }
+            return target;
         }
-        getWorldPosition(target){
-            const result = target || new Vector3();
-            result.copy(this.position);
-            let current = this.parent;
-            while(current){
-                result.add(current.position);
-                current = current.parent;
+        getWorldScale(target = new Vector3()) {
+            target.copy(this.scale);
+            let parent = this.parent;
+            while (parent) {
+                target.multiply(parent.scale);
+                parent = parent.parent;
             }
-            return result;
-        }
-        lookAt(){
-            // Stub: no-op
-        }
-        clone(){
-            const clone = new Object3D();
-            clone.position.copy(this.position);
-            clone.rotation.copy(this.rotation);
-            clone.scale.copy(this.scale);
-            clone.userData = JSON.parse(JSON.stringify(this.userData || {}));
-            return clone;
-        }
-    }
-
-    class Group extends Object3D {
-        constructor(){
-            super();
+            return target;
         }
     }
 
     class Scene extends Object3D {
-        constructor(){
+        constructor() {
             super();
             this.fog = null;
-        }
-    }
-
-    class FogExp2 {
-        constructor(color, density){
-            this.color = new Color(color);
-            this.density = density || 0.00025;
+            this.background = null;
         }
     }
 
     class Camera extends Object3D {
-        constructor(){
+        constructor() {
             super();
+            this.up = new Vector3(0, 1, 0);
+            this.matrixWorldNeedsUpdate = true;
         }
     }
 
     class PerspectiveCamera extends Camera {
-        constructor(fov=50, aspect=1, near=0.1, far=2000){
+        constructor(fov = 50, aspect = 1, near = 0.1, far = 2000) {
             super();
-            this.isPerspectiveCamera = true;
+            this.type = 'PerspectiveCamera';
             this.fov = fov;
             this.aspect = aspect;
             this.near = near;
             this.far = far;
+            this.updateProjectionMatrix();
         }
-        updateProjectionMatrix(){
-            // Stub: nothing to do
-        }
-    }
-
-    class Material {
-        constructor(params={}){
-            this.transparent = !!params.transparent;
-            this.opacity = isNumber(params.opacity) ? params.opacity : 1;
-            this.depthTest = params.depthTest !== undefined ? params.depthTest : true;
-            this.depthWrite = params.depthWrite !== undefined ? params.depthWrite : true;
-            this.side = params.side !== undefined ? params.side : THREE.FrontSide;
-        }
-        dispose(){
-            // noop
+        updateProjectionMatrix() {
+            this._tanHalfFov = Math.tan((this.fov * DEG2RAD) / 2);
         }
     }
 
-    class MeshBasicMaterial extends Material {
-        constructor(params={}){
-            super(params);
-            this.color = new Color(params.color !== undefined ? params.color : 0xffffff);
-        }
-    }
-
-    class MeshStandardMaterial extends Material {
-        constructor(params={}){
-            super(params);
-            this.color = new Color(params.color !== undefined ? params.color : 0xffffff);
-            this.emissive = new Color(params.emissive !== undefined ? params.emissive : 0x000000);
-            this.emissiveIntensity = isNumber(params.emissiveIntensity) ? params.emissiveIntensity : 1;
-            this.roughness = isNumber(params.roughness) ? params.roughness : 1;
-            this.metalness = isNumber(params.metalness) ? params.metalness : 0;
-        }
-    }
-
-    class SpriteMaterial extends Material {
-        constructor(params={}){
-            super(params);
-            this.map = params.map || null;
-        }
-    }
-
-    class Texture {
-        constructor(image){
-            this.image = image || null;
-            this.needsUpdate = false;
-        }
-        dispose(){
-            this.image = null;
-        }
-    }
-
-    class CanvasTexture extends Texture {
-        constructor(canvas){
-            super(canvas);
-            this.minFilter = THREE.LinearFilter;
-            this.encoding = THREE.LinearEncoding;
+    class FogExp2 {
+        constructor(color = 0xffffff, density = 0.00025) {
+            this.color = new Color(color);
+            this.density = density;
         }
     }
 
     class Geometry {
-        constructor(){
+        constructor() {
             this.parameters = {};
         }
     }
 
     class SphereGeometry extends Geometry {
-        constructor(radius=1){
+        constructor(radius = 1) {
             super();
+            this.type = 'SphereGeometry';
+            this.parameters.radius = radius;
+        }
+    }
+
+    class IcosahedronGeometry extends Geometry {
+        constructor(radius = 1) {
+            super();
+            this.type = 'IcosahedronGeometry';
             this.parameters.radius = radius;
         }
     }
 
     class RingGeometry extends Geometry {
-        constructor(innerRadius=0, outerRadius=1, thetaSegments=8){
+        constructor(innerRadius = 0.5, outerRadius = 1) {
             super();
+            this.type = 'RingGeometry';
             this.parameters.innerRadius = innerRadius;
             this.parameters.outerRadius = outerRadius;
-            this.parameters.thetaSegments = thetaSegments;
         }
     }
 
-    class IcosahedronGeometry extends Geometry {
-        constructor(radius=1, detail=0){
-            super();
-            this.parameters.radius = radius;
-            this.parameters.detail = detail;
+    class Material {
+        constructor(params = {}) {
+            this.transparent = !!params.transparent;
+            this.opacity = (typeof params.opacity === 'number') ? params.opacity : 1;
+            this.visible = true;
         }
     }
 
-    class Object3DWithMaterial extends Object3D {
-        constructor(){
-            super();
-            this.material = null;
+    class MeshStandardMaterial extends Material {
+        constructor(params = {}) {
+            super(params);
+            this.color = new Color(params.color !== undefined ? params.color : 0xffffff);
+            this.emissive = new Color(params.emissive !== undefined ? params.emissive : 0x000000);
+            this.emissiveIntensity = params.emissiveIntensity !== undefined ? params.emissiveIntensity : 0;
+            this.roughness = params.roughness !== undefined ? params.roughness : 1;
+            this.metalness = params.metalness !== undefined ? params.metalness : 0;
         }
     }
 
-    class Mesh extends Object3DWithMaterial {
-        constructor(geometry, material){
-            super();
-            this.geometry = geometry || new Geometry();
-            this.material = material || new Material();
+    class MeshBasicMaterial extends Material {
+        constructor(params = {}) {
+            super(params);
+            this.color = new Color(params.color !== undefined ? params.color : 0xffffff);
+            this.side = params.side !== undefined ? params.side : THREE.FrontSide;
         }
     }
 
-    class Sprite extends Object3DWithMaterial {
-        constructor(material){
+    class Texture {
+        constructor(image = null) {
+            this.image = image;
+            this.needsUpdate = true;
+            this.encoding = THREE.LinearEncoding;
+        }
+    }
+
+    class CanvasTexture extends Texture {
+        constructor(canvas) {
+            super(canvas);
+            this.minFilter = THREE.LinearFilter;
+        }
+    }
+
+    class SpriteMaterial extends Material {
+        constructor(params = {}) {
+            super(params);
+            this.map = params.map || null;
+            this.depthTest = params.depthTest !== undefined ? params.depthTest : true;
+            this.depthWrite = params.depthWrite !== undefined ? params.depthWrite : true;
+        }
+    }
+
+    class Mesh extends Object3D {
+        constructor(geometry = new Geometry(), material = new MeshBasicMaterial()) {
             super();
-            this.material = material || new SpriteMaterial();
+            this.type = 'Mesh';
+            this.geometry = geometry;
+            this.material = material;
+            this.isMesh = true;
+        }
+    }
+
+    class Sprite extends Object3D {
+        constructor(material = new SpriteMaterial()) {
+            super();
+            this.type = 'Sprite';
+            this.material = material;
+            this.center = new Vector2(0.5, 0.5);
+            this.isSprite = true;
+        }
+    }
+
+    class Group extends Object3D {
+        constructor() {
+            super();
+            this.type = 'Group';
         }
     }
 
     class Light extends Object3D {
-        constructor(color=0xffffff, intensity=1){
+        constructor(color = 0xffffff, intensity = 1) {
             super();
             this.color = new Color(color);
             this.intensity = intensity;
@@ -443,121 +486,439 @@
     }
 
     class AmbientLight extends Light {
-        constructor(color, intensity){
+        constructor(color = 0xffffff, intensity = 1) {
             super(color, intensity);
+            this.type = 'AmbientLight';
         }
     }
 
     class DirectionalLight extends Light {
-        constructor(color, intensity){
+        constructor(color = 0xffffff, intensity = 1) {
             super(color, intensity);
-            this.position = new Vector3();
+            this.type = 'DirectionalLight';
+            this.target = new Object3D();
         }
     }
 
     class PointLight extends Light {
-        constructor(color, intensity, distance){
+        constructor(color = 0xffffff, intensity = 1, distance = 0) {
             super(color, intensity);
-            this.distance = distance !== undefined ? distance : 0;
-            this.position = new Vector3();
+            this.type = 'PointLight';
+            this.distance = distance;
         }
     }
 
-    class Raycaster {
-        constructor(){
-            this.ray = {
-                origin: new Vector3(),
-                direction: new Vector3(0, 0, -1)
-            };
+    class Spherical {
+        constructor(radius = 1, phi = 0, theta = 0) {
+            this.radius = radius;
+            this.phi = phi;
+            this.theta = theta;
         }
-        setFromCamera(coords, camera){
-            this.ray.origin.set(0, 0, 0);
-            if(camera && camera.position){
-                this.ray.origin.copy(camera.position);
+        set(radius, phi, theta) {
+            this.radius = radius;
+            this.phi = phi;
+            this.theta = theta;
+            return this;
+        }
+        makeSafe() {
+            const EPS = 1e-6;
+            this.phi = THREE.MathUtils.clamp(this.phi, EPS, Math.PI - EPS);
+            return this;
+        }
+        setFromVector3(v) {
+            this.radius = v.length();
+            if (this.radius === 0) {
+                this.theta = 0;
+                this.phi = 0;
+            } else {
+                this.theta = Math.atan2(v.x, v.z);
+                this.phi = Math.acos(THREE.MathUtils.clamp(v.y / this.radius, -1, 1));
             }
-            this.ray.direction.set(coords.x || 0, coords.y || 0, -1).normalize();
-        }
-        intersectObjects(){
-            return [];
+            return this;
         }
     }
 
-    class WebGLRenderer {
-        constructor(params={}){
-            this.parameters = params;
-            this.domElement = (typeof document !== 'undefined') ? document.createElement('canvas') : { style: {}, addEventListener(){}, removeEventListener(){} };
-            this.outputEncoding = THREE.LinearEncoding;
-            this._pixelRatio = 1;
-            this._clearColor = { color: 0x000000, alpha: 1 };
-        }
-        setSize(width, height){
-            if(this.domElement){
-                this.domElement.width = width;
-                this.domElement.height = height;
-                if(this.domElement.style){
-                    this.domElement.style.width = width + 'px';
-                    this.domElement.style.height = height + 'px';
-                }
-            }
-        }
-        setPixelRatio(ratio){
-            this._pixelRatio = ratio;
-        }
-        setClearColor(color, alpha){
-            this._clearColor = { color, alpha };
-        }
-        render(){
-            // Stub: no-op
-        }
-        dispose(){
-            // Stub: no-op
-        }
-    }
-
-    THREE.EventDispatcher = EventDispatcher;
-    THREE.Vector3 = Vector3;
     THREE.Vector2 = Vector2;
-    THREE.Euler = Euler;
+    THREE.Vector3 = Vector3;
     THREE.Color = Color;
+    THREE.EventDispatcher = EventDispatcher;
     THREE.Object3D = Object3D;
-    THREE.Group = Group;
     THREE.Scene = Scene;
-    THREE.FogExp2 = FogExp2;
     THREE.Camera = Camera;
     THREE.PerspectiveCamera = PerspectiveCamera;
-    THREE.Material = Material;
-    THREE.MeshBasicMaterial = MeshBasicMaterial;
-    THREE.MeshStandardMaterial = MeshStandardMaterial;
-    THREE.SpriteMaterial = SpriteMaterial;
-    THREE.Texture = Texture;
-    THREE.CanvasTexture = CanvasTexture;
+    THREE.FogExp2 = FogExp2;
     THREE.Geometry = Geometry;
     THREE.SphereGeometry = SphereGeometry;
-    THREE.RingGeometry = RingGeometry;
     THREE.IcosahedronGeometry = IcosahedronGeometry;
+    THREE.RingGeometry = RingGeometry;
+    THREE.Material = Material;
+    THREE.MeshStandardMaterial = MeshStandardMaterial;
+    THREE.MeshBasicMaterial = MeshBasicMaterial;
+    THREE.Texture = Texture;
+    THREE.CanvasTexture = CanvasTexture;
+    THREE.SpriteMaterial = SpriteMaterial;
     THREE.Mesh = Mesh;
     THREE.Sprite = Sprite;
-    THREE.Light = Light;
+    THREE.Group = Group;
     THREE.AmbientLight = AmbientLight;
     THREE.DirectionalLight = DirectionalLight;
     THREE.PointLight = PointLight;
-    THREE.Raycaster = Raycaster;
-    THREE.WebGLRenderer = WebGLRenderer;
+    THREE.Spherical = Spherical;
 
+    THREE.FrontSide = 1;
+    THREE.BackSide = 0;
     THREE.DoubleSide = 2;
-    THREE.FrontSide = 0;
-    THREE.BackSide = 1;
-    THREE.LinearFilter = 'LinearFilter';
-    THREE.LinearEncoding = 'LinearEncoding';
-    THREE.sRGBEncoding = 'sRGBEncoding';
+    THREE.LinearFilter = 'linear';
+    THREE.LinearEncoding = 'linear';
+    THREE.sRGBEncoding = 'sRGB';
 
-    THREE.__CODEx_STUB__ = true;
-
-    if(!global.THREE){
-        global.THREE = THREE;
-    } else {
-        for(const key of Object.keys(THREE)){
-            global.THREE[key] = THREE[key];
+    class Raycaster {
+        constructor(origin = new Vector3(), direction = new Vector3(0, 0, -1)) {
+            this.ray = {
+                origin: origin.clone(),
+                direction: direction.clone().normalize()
+            };
+            this.params = {};
+            this._ndc = new Vector2();
+        }
+        setFromCamera(coords, camera) {
+            this._ndc.copy(coords);
+            this._camera = camera;
+        }
+        _flatten(objects, recursive, result) {
+            if (!objects) {
+                return;
+            }
+            if (Array.isArray(objects)) {
+                objects.forEach(obj => this._flatten(obj, recursive, result));
+                return;
+            }
+            if (objects.visible === false) {
+                return;
+            }
+            result.push(objects);
+            if (recursive && objects.children && objects.children.length) {
+                objects.children.forEach(child => this._flatten(child, true, result));
+            }
+        }
+        intersectObjects(objects, recursive = false) {
+            const list = [];
+            this._flatten(objects, recursive, list);
+            const cache = THREE.__pickCache;
+            if (!cache) {
+                return [];
+            }
+            const hits = [];
+            const pointer = this._ndc;
+            list.forEach(object => {
+                const entry = cache.get(object);
+                if (!entry) {
+                    return;
+                }
+                const dx = pointer.x - entry.ndcX;
+                const dy = pointer.y - entry.ndcY;
+                const distSq = dx * dx + dy * dy;
+                if (entry.type === 'ring') {
+                    if (entry.outerRadiusNDC <= 0) {
+                        return;
+                    }
+                    const outerSq = entry.outerRadiusNDC * entry.outerRadiusNDC;
+                    const innerSq = entry.innerRadiusNDC * entry.innerRadiusNDC;
+                    if (distSq <= outerSq && distSq >= innerSq) {
+                        hits.push({
+                            distance: entry.distance,
+                            point: entry.worldPosition.clone(),
+                            object
+                        });
+                    }
+                    return;
+                }
+                if (entry.radiusNDC <= 0) {
+                    return;
+                }
+                if (distSq <= entry.radiusNDC * entry.radiusNDC) {
+                    hits.push({
+                        distance: entry.distance,
+                        point: entry.worldPosition.clone(),
+                        object
+                    });
+                }
+            });
+            hits.sort((a, b) => a.distance - b.distance);
+            return hits;
         }
     }
+
+    THREE.Raycaster = Raycaster;
+
+    class WebGLRenderer {
+        constructor(params = {}) {
+            this.domElement = global.document ? global.document.createElement('canvas') : null;
+            if (!this.domElement) {
+                throw new Error('WebGLRenderer requires a DOM-capable environment.');
+            }
+            this.domElement.width = 300;
+            this.domElement.height = 150;
+            this.domElement.style.width = '300px';
+            this.domElement.style.height = '150px';
+            this.domElement.style.display = 'block';
+            this._ctx = this.domElement.getContext('2d', { alpha: !!params.alpha });
+            this._pixelRatio = 1;
+            this._width = 300;
+            this._height = 150;
+            this._clearStyle = 'rgba(0,0,0,0)';
+            this.outputEncoding = THREE.LinearEncoding;
+        }
+        setSize(width, height, updateStyle = true) {
+            this._width = width;
+            this._height = height;
+            const w = Math.max(1, Math.floor(width * this._pixelRatio));
+            const h = Math.max(1, Math.floor(height * this._pixelRatio));
+            this.domElement.width = w;
+            this.domElement.height = h;
+            if (updateStyle !== false) {
+                this.domElement.style.width = `${width}px`;
+                this.domElement.style.height = `${height}px`;
+            }
+        }
+        setPixelRatio(ratio) {
+            if (ratio <= 0 || !Number.isFinite(ratio)) {
+                return;
+            }
+            this._pixelRatio = ratio;
+            this.setSize(this._width, this._height, false);
+        }
+        setClearColor(color, alpha = 1) {
+            const c = new Color(color);
+            this._clearStyle = c.getStyle(alpha);
+        }
+        dispose() {
+            this._ctx = null;
+            this.domElement = null;
+        }
+        _computeCameraBasis(camera) {
+            const target = (camera && camera.__controlTarget) ? camera.__controlTarget : new Vector3();
+            const position = camera.position.clone();
+            const forward = target.clone().sub(position);
+            if (forward.lengthSq() === 0) {
+                forward.set(0, 0, -1);
+            }
+            forward.normalize();
+            const up = camera.up ? camera.up.clone().normalize() : new Vector3(0, 1, 0);
+            const right = new Vector3().crossVectors(forward, up);
+            if (right.lengthSq() === 0) {
+                right.set(1, 0, 0);
+            } else {
+                right.normalize();
+            }
+            const trueUp = new Vector3().crossVectors(right, forward).normalize();
+            return { position, target, forward, right, up: trueUp };
+        }
+        render(scene, camera) {
+            if (!this._ctx || !scene || !camera) {
+                return;
+            }
+            const ctx = this._ctx;
+            const pixelRatio = this._pixelRatio;
+            ctx.save();
+            ctx.setTransform(1, 0, 0, 1, 0, 0);
+            ctx.fillStyle = this._clearStyle;
+            ctx.fillRect(0, 0, this.domElement.width, this.domElement.height);
+            ctx.restore();
+            ctx.save();
+            ctx.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+            ctx.clearRect(0, 0, this._width, this._height);
+            ctx.fillStyle = this._clearStyle;
+            ctx.fillRect(0, 0, this._width, this._height);
+
+            const basis = this._computeCameraBasis(camera);
+            const { position: eye, forward, right, up } = basis;
+            const aspect = camera.aspect || (this._width / this._height);
+            const near = camera.near || 0.1;
+            const far = camera.far || 2000;
+            const items = [];
+            THREE.__pickCache = new Map();
+            scene.traverse(object => {
+                if (!object.visible) {
+                    return;
+                }
+                if (!object.isMesh && !object.isSprite) {
+                    return;
+                }
+                const worldPosition = object.getWorldPosition(new Vector3());
+                const toPoint = worldPosition.clone().sub(eye);
+                const z = toPoint.dot(forward);
+                if (z <= near || z >= far) {
+                    return;
+                }
+                const halfHeight = z * Math.tan((camera.fov * DEG2RAD) / 2);
+                const halfWidth = halfHeight * aspect;
+                if (halfHeight <= 0 || halfWidth <= 0) {
+                    return;
+                }
+                const xComponent = toPoint.dot(right);
+                const yComponent = toPoint.dot(up);
+                const ndcX = xComponent / halfWidth;
+                const ndcY = yComponent / halfHeight;
+                if (ndcX < -1.5 || ndcX > 1.5 || ndcY < -1.5 || ndcY > 1.5) {
+                    // outside view frustum
+                }
+                const screenX = (ndcX * 0.5 + 0.5) * this._width;
+                const screenY = (-ndcY * 0.5 + 0.5) * this._height;
+                const distance = worldPosition.distanceTo(eye);
+                if (object.isMesh) {
+                    const geometry = object.geometry || {};
+                    const params = geometry.parameters || {};
+                    const scale = object.getWorldScale(new Vector3());
+                    let entry = null;
+                    if (geometry.type === 'RingGeometry') {
+                        const inner = (params.innerRadius || 0) * (scale.x + scale.y) / 2;
+                        const outer = (params.outerRadius || 0) * (scale.x + scale.y) / 2;
+                        const outerNDC = outer / halfHeight;
+                        const innerNDC = inner / halfHeight;
+                        const outerPx = outerNDC * this._height * 0.5;
+                        const innerPx = innerNDC * this._height * 0.5;
+                        items.push({
+                            object,
+                            type: 'ring',
+                            screenX,
+                            screenY,
+                            outerPx,
+                            innerPx,
+                            outerNDC,
+                            innerNDC,
+                            ndcX,
+                            ndcY,
+                            ndcZ: z,
+                            distance,
+                            renderOrder: object.renderOrder || 0
+                        });
+                        entry = {
+                            type: 'ring',
+                            ndcX,
+                            ndcY,
+                            outerRadiusNDC: Math.abs(outerNDC),
+                            innerRadiusNDC: Math.abs(innerNDC),
+                            distance,
+                            worldPosition
+                        };
+                    } else {
+                        const radius = (params.radius || 1) * (scale.x + scale.y + scale.z) / 3;
+                        const radiusNDC = radius / halfHeight;
+                        const radiusPx = radiusNDC * this._height * 0.5;
+                        items.push({
+                            object,
+                            type: 'sphere',
+                            screenX,
+                            screenY,
+                            radiusPx,
+                            radiusNDC,
+                            ndcX,
+                            ndcY,
+                            ndcZ: z,
+                            distance,
+                            renderOrder: object.renderOrder || 0
+                        });
+                        entry = {
+                            type: 'sphere',
+                            ndcX,
+                            ndcY,
+                            radiusNDC: Math.abs(radiusNDC),
+                            distance,
+                            worldPosition
+                        };
+                    }
+                    if (entry) {
+                        THREE.__pickCache.set(object, entry);
+                    }
+                } else if (object.isSprite) {
+                    const scale = object.getWorldScale(new Vector3());
+                    const widthWorld = scale.x;
+                    const heightWorld = scale.y;
+                    const widthNDC = widthWorld / halfWidth;
+                    const heightNDC = heightWorld / halfHeight;
+                    const widthPx = widthNDC * this._width * 0.5;
+                    const heightPx = heightNDC * this._height * 0.5;
+                    items.push({
+                        object,
+                        type: 'sprite',
+                        screenX,
+                        screenY,
+                        widthPx,
+                        heightPx,
+                        ndcX,
+                        ndcY,
+                        ndcZ: z,
+                        distance,
+                        renderOrder: object.renderOrder || 0
+                    });
+                }
+            });
+
+            items.sort((a, b) => {
+                if (a.renderOrder !== b.renderOrder) {
+                    return a.renderOrder - b.renderOrder;
+                }
+                return b.ndcZ - a.ndcZ;
+            });
+
+            items.forEach(item => {
+                if (item.type === 'sphere') {
+                    const material = item.object.material || new MeshStandardMaterial();
+                    const opacity = material.transparent ? material.opacity : 1;
+                    const baseColor = material.color ? material.color.clone() : new Color(0xffffff);
+                    const emissive = material.emissive ? material.emissive.clone() : new Color(0x000000);
+                    if (material.emissiveIntensity) {
+                        emissive.multiplyScalar(material.emissiveIntensity);
+                        baseColor.add(emissive);
+                    }
+                    ctx.beginPath();
+                    ctx.arc(item.screenX, item.screenY, Math.max(0, item.radiusPx), 0, Math.PI * 2);
+                    ctx.fillStyle = baseColor.getStyle(opacity);
+                    ctx.fill();
+                } else if (item.type === 'ring') {
+                    const material = item.object.material || new MeshBasicMaterial();
+                    const opacity = material.transparent ? material.opacity : 1;
+                    const color = material.color ? material.color.clone() : new Color(0xffffff);
+                    const outerRadius = Math.max(0, item.outerPx);
+                    const innerRadius = Math.max(0, item.innerPx);
+                    ctx.beginPath();
+                    ctx.arc(item.screenX, item.screenY, outerRadius, 0, Math.PI * 2, false);
+                    ctx.arc(item.screenX, item.screenY, innerRadius, 0, Math.PI * 2, true);
+                    ctx.closePath();
+                    ctx.fillStyle = color.getStyle(opacity);
+                    ctx.globalAlpha = opacity;
+                    ctx.fill();
+                    ctx.globalAlpha = 1;
+                } else if (item.type === 'sprite') {
+                    const material = item.object.material || new SpriteMaterial();
+                    const map = material.map;
+                    if (!map || !map.image) {
+                        return;
+                    }
+                    const opacity = material.transparent ? material.opacity : 1;
+                    ctx.save();
+                    ctx.globalAlpha = opacity;
+                    ctx.drawImage(
+                        map.image,
+                        item.screenX - item.widthPx * (item.object.center.x),
+                        item.screenY - item.heightPx * (item.object.center.y),
+                        item.widthPx,
+                        item.heightPx
+                    );
+                    ctx.restore();
+                }
+            });
+
+            ctx.restore();
+        }
+    }
+
+    THREE.WebGLRenderer = WebGLRenderer;
+
+    THREE.requestAnimationFrame = global.requestAnimationFrame ? global.requestAnimationFrame.bind(global) : function(cb) {
+        return setTimeout(cb, 16);
+    };
+
+    global.THREE = THREE;
 })(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));


### PR DESCRIPTION
## Summary
- implement a lightweight offline-compatible THREE namespace with vector math, materials, raycasting, and a canvas-backed renderer so the skill universe can draw without the official build
- replace the OrbitControls stub with functional mouse-driven orbit, pan, and zoom logic tailored to the custom renderer

## Testing
- node - <<'NODE'
const noop = () => {};
const ctx = {
  save: noop,
  restore: noop,
  setTransform: noop,
  fillRect: noop,
  clearRect: noop,
  beginPath: noop,
  arc: noop,
  closePath: noop,
  fill: noop,
  stroke: noop,
  drawImage: noop,
  globalAlpha: 1,
  fillStyle: 'rgba(0,0,0,0)',
  strokeStyle: 'rgba(0,0,0,0)'
};
const canvas = {
  width: 0,
  height: 0,
  style: {},
  getContext: () => ctx,
  addEventListener: noop,
  removeEventListener: noop,
  ownerDocument: null
};
global.window = global;
global.document = {
  createElement: () => ({ ...canvas })
};
require('./js/vendor/three.min.js');
require('./js/vendor/OrbitControls.js');
console.log('THREE available:', typeof THREE !== 'undefined');
console.log('Renderer:', typeof THREE.WebGLRenderer);
console.log('OrbitControls:', typeof THREE.OrbitControls);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68d1bc021f608321b04967be88373006