### PR TITLE
Update skill tree naming to Skill Universe

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,7 +236,7 @@
         <div class="modal-content">
             <div id="skill-tree-header">
                 <button id="skill-back-btn" class="hidden" type="button">&larr; Back</button>
-                <h2 id="skill-tree-title">Skill Galaxy</h2>
+                <h2 id="skill-tree-title">Skill Universe</h2>
                 <div class="skill-tree-controls">
                     <form id="skill-search-form" class="skill-tree-search" role="search">
                         <input

--- a/js/skill-universe-renderer.js
+++ b/js/skill-universe-renderer.js
@@ -1074,7 +1074,7 @@
                 return;
             }
             const { galaxy, constellation, starSystem, star } = this.currentSelection;
-            const breadcrumbs = [{ label: 'All Galaxies' }];
+            const breadcrumbs = [{ label: 'Skill Universe' }];
 
             if (galaxy) {
                 breadcrumbs.push({
@@ -1104,7 +1104,7 @@
                 });
             }
 
-            let title = 'Skill Galaxies';
+            let title = 'Skill Universe';
             if (star) {
                 title = star;
             } else if (starSystem) {


### PR DESCRIPTION
## Summary
- rename the skill tree modal heading to "Skill Universe"
- update the renderer's default title and breadcrumb label to reflect the new Skill Universe name

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1ce255ee88321b27381d4b217ad12