### PR TITLE
Handle delayed skill tree data in renderer

### DIFF
--- a/js/skill-universe-renderer.js
+++ b/js/skill-universe-renderer.js
@@ -205,12 +205,24 @@
             this.currentView = 'galaxies';
             this.currentSelection = { galaxy: null, constellation: null, starSystem: null, star: null };
 
+            this.needsUniverseBuild = false;
+
             this._setupLights();
-            this._buildUniverse();
+            const initialSkillTree = this.getSkillTree() || {};
+            if (Object.keys(initialSkillTree).length) {
+                this._buildUniverse();
+            } else {
+                this.needsUniverseBuild = true;
+            }
             this._bindEvents();
             this._updateViewUI();
             this._animate = this._animate.bind(this);
             this._animate();
+        }
+
+        rebuildUniverse() {
+            this._buildUniverse();
+            this.refreshStars();
         }
 
         refreshStars() {
@@ -382,8 +394,11 @@
             const skillTree = this.getSkillTree() || {};
             const galaxyNames = Object.keys(skillTree);
             if (!galaxyNames.length) {
+                this.needsUniverseBuild = true;
                 return;
             }
+
+            this.needsUniverseBuild = false;
 
             galaxyNames.forEach((galaxyName, index) => {
                 const galaxyData = skillTree[galaxyName] || {};


### PR DESCRIPTION
## Summary
- add a rebuildUniverse entry point and track when the 3D scene still needs to be built
- defer building the skill tree scene until data is available and trigger rebuilds when async data loads
- guard the skills modal behind available data so users do not open an empty universe

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d1d85174548321b34d15e91fb6a172