### PR TITLE
Handle non-model avatar images

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -380,6 +380,10 @@ video.avatar-circle {
     background-color: rgba(223, 232, 242, 0.9);
 }
 
+img.avatar-circle {
+    object-fit: cover;
+}
+
 model-viewer.avatar-circle {
     --poster-color: transparent;
     background: radial-gradient(circle at 50% 40%, rgba(223, 232, 242, 0.75), rgba(195, 212, 223, 0.55));


### PR DESCRIPTION
## Summary
- detect non-GLB/GLTF avatar URLs and swap the viewer to an `<img>` element so the placeholder mesh never appears
- preserve the model-viewer configuration for GLB/GLTF avatars and keep the placeholder styling in sync
- ensure captured raster images fill the avatar circle by applying object-fit styling

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d1f612829083218d8da27a65bdcd06