### PR TITLE
Enhance Three.js shim with buffer geometry support

### DIFF
--- a/js/skill-universe-renderer.js
+++ b/js/skill-universe-renderer.js
@@ -228,6 +228,9 @@
             this.renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
             this.renderer.outputEncoding = THREE.sRGBEncoding;
             this.renderer.setSize(width, height, false);
+            this.renderer.domElement.style.width = '100%';
+            this.renderer.domElement.style.height = '100%';
+            this.renderer.domElement.style.display = 'block';
             this.renderer.setPixelRatio(global.devicePixelRatio || 1);
             this.renderer.setClearColor(0x02030b, 1);
             this.container.innerHTML = '';
@@ -325,6 +328,8 @@
             this.camera.aspect = width / height;
             this.camera.updateProjectionMatrix();
             this.renderer.setSize(width, height, false);
+            this.renderer.domElement.style.width = '100%';
+            this.renderer.domElement.style.height = '100%';
             this.render();
         }
 

--- a/js/vendor/three.min.js
+++ b/js/vendor/three.min.js
@@ -203,6 +203,12 @@
             this.b = (value & 255) / 255;
             return this;
         }
+        setRGB(r, g, b) {
+            this.r = r;
+            this.g = g;
+            this.b = b;
+            return this;
+        }
         copy(color) {
             this.r = color.r;
             this.g = color.g;
@@ -368,6 +374,79 @@
         }
     }
 
+    class BufferAttribute {
+        constructor(array, itemSize, normalized = false) {
+            if (!array || typeof array.length !== 'number') {
+                throw new Error('BufferAttribute requires a valid array.');
+            }
+            if (!Number.isFinite(itemSize) || itemSize <= 0) {
+                throw new Error('BufferAttribute requires a positive itemSize.');
+            }
+            this.array = array;
+            this.itemSize = itemSize;
+            this.count = array.length / itemSize;
+            this.normalized = normalized;
+            this.needsUpdate = false;
+        }
+        setX(index, x) {
+            this.array[index * this.itemSize] = x;
+            return this;
+        }
+        setY(index, y) {
+            this.array[index * this.itemSize + 1] = y;
+            return this;
+        }
+        setZ(index, z) {
+            this.array[index * this.itemSize + 2] = z;
+            return this;
+        }
+        clone() {
+            const array = this.array.slice ? this.array.slice(0) : new this.array.constructor(this.array);
+            return new BufferAttribute(array, this.itemSize, this.normalized);
+        }
+        copyArray(array) {
+            this.array.set(array);
+            return this;
+        }
+    }
+
+    class BufferGeometry {
+        constructor() {
+            this.attributes = {};
+            this.boundingSphere = null;
+            this._drawRange = { start: 0, count: Infinity };
+        }
+        setAttribute(name, attribute) {
+            if (!(attribute instanceof BufferAttribute) && attribute && attribute.array && attribute.itemSize) {
+                attribute = new BufferAttribute(attribute.array, attribute.itemSize, attribute.normalized || false);
+            }
+            if (!(attribute instanceof BufferAttribute)) {
+                throw new Error('BufferGeometry.setAttribute expects a BufferAttribute.');
+            }
+            this.attributes[name] = attribute;
+            return this;
+        }
+        getAttribute(name) {
+            return this.attributes[name] || null;
+        }
+        deleteAttribute(name) {
+            delete this.attributes[name];
+            return this;
+        }
+        setDrawRange(start, count) {
+            this._drawRange.start = start;
+            this._drawRange.count = count;
+            return this;
+        }
+        get drawRange() {
+            return this._drawRange;
+        }
+        dispose() {
+            this.attributes = {};
+            this.boundingSphere = null;
+        }
+    }
+
     class Geometry {
         constructor() {
             this.parameters = {};
@@ -450,6 +529,17 @@
         }
     }
 
+    class PointsMaterial extends Material {
+        constructor(params = {}) {
+            super(params);
+            this.size = params.size !== undefined ? params.size : 1;
+            this.sizeAttenuation = params.sizeAttenuation !== undefined ? params.sizeAttenuation : true;
+            this.color = new Color(params.color !== undefined ? params.color : 0xffffff);
+            this.vertexColors = !!params.vertexColors;
+            this.depthWrite = params.depthWrite !== undefined ? params.depthWrite : true;
+        }
+    }
+
     class Mesh extends Object3D {
         constructor(geometry = new Geometry(), material = new MeshBasicMaterial()) {
             super();
@@ -457,6 +547,16 @@
             this.geometry = geometry;
             this.material = material;
             this.isMesh = true;
+        }
+    }
+
+    class Points extends Object3D {
+        constructor(geometry = new BufferGeometry(), material = new PointsMaterial()) {
+            super();
+            this.type = 'Points';
+            this.geometry = geometry;
+            this.material = material;
+            this.isPoints = true;
         }
     }
 
@@ -547,6 +647,8 @@
     THREE.Camera = Camera;
     THREE.PerspectiveCamera = PerspectiveCamera;
     THREE.FogExp2 = FogExp2;
+    THREE.BufferAttribute = BufferAttribute;
+    THREE.BufferGeometry = BufferGeometry;
     THREE.Geometry = Geometry;
     THREE.SphereGeometry = SphereGeometry;
     THREE.IcosahedronGeometry = IcosahedronGeometry;
@@ -557,7 +659,9 @@
     THREE.Texture = Texture;
     THREE.CanvasTexture = CanvasTexture;
     THREE.SpriteMaterial = SpriteMaterial;
+    THREE.PointsMaterial = PointsMaterial;
     THREE.Mesh = Mesh;
+    THREE.Points = Points;
     THREE.Sprite = Sprite;
     THREE.Group = Group;
     THREE.AmbientLight = AmbientLight;
@@ -742,6 +846,40 @@
                 if (!object.visible) {
                     return;
                 }
+                if (object.isPoints) {
+                    const geometry = object.geometry;
+                    const material = object.material || new PointsMaterial();
+                    if (!geometry || typeof geometry.getAttribute !== 'function') {
+                        return;
+                    }
+                    const positionAttr = geometry.getAttribute('position');
+                    if (!positionAttr || !positionAttr.array || !positionAttr.array.length) {
+                        return;
+                    }
+                    const worldPosition = object.getWorldPosition(new Vector3());
+                    const worldScale = object.getWorldScale(new Vector3());
+                    const centerVector = worldPosition.clone().sub(eye);
+                    const centerZ = centerVector.dot(forward);
+                    const colorsAttr = geometry.getAttribute('color');
+                    items.push({
+                        object,
+                        type: 'points',
+                        positions: positionAttr.array,
+                        positionItemSize: positionAttr.itemSize || 3,
+                        colors: colorsAttr && colorsAttr.array ? colorsAttr.array : null,
+                        color: material.color ? material.color.clone() : new Color(0xffffff),
+                        vertexColors: !!material.vertexColors,
+                        size: material.size !== undefined ? material.size : 1,
+                        sizeAttenuation: material.sizeAttenuation !== undefined ? material.sizeAttenuation : true,
+                        opacity: material.transparent ? material.opacity : 1,
+                        worldPosition,
+                        worldScale,
+                        distance: worldPosition.distanceTo(eye),
+                        ndcZ: centerZ,
+                        renderOrder: object.renderOrder || 0
+                    });
+                    return;
+                }
                 if (!object.isMesh && !object.isSprite) {
                     return;
                 }
@@ -890,6 +1028,59 @@
                     ctx.globalAlpha = opacity;
                     ctx.fill();
                     ctx.globalAlpha = 1;
+                } else if (item.type === 'points') {
+                    const positions = item.positions || [];
+                    if (!positions.length) {
+                        return;
+                    }
+                    const step = Math.max(1, item.positionItemSize || 3);
+                    const opacity = THREE.MathUtils.clamp(item.opacity !== undefined ? item.opacity : 1, 0, 1);
+                    const baseStyle = item.vertexColors ? null : item.color.getStyle(opacity);
+                    const scale = item.worldScale || new Vector3(1, 1, 1);
+                    const basePosition = item.worldPosition || new Vector3();
+                    const colors = item.vertexColors ? (item.colors || null) : null;
+                    const world = new Vector3();
+                    const toPointVec = new Vector3();
+                    for (let i = 0; i <= positions.length - step; i += step) {
+                        const px = positions[i];
+                        const py = step > 1 ? positions[i + 1] : 0;
+                        const pz = step > 2 ? positions[i + 2] : 0;
+                        world.copy(basePosition);
+                        world.x += px * scale.x;
+                        world.y += py * scale.y;
+                        world.z += pz * scale.z;
+                        toPointVec.subVectors(world, eye);
+                        const z = toPointVec.dot(forward);
+                        if (z <= near || z >= far) {
+                            continue;
+                        }
+                        const halfHeight = z * Math.tan((camera.fov * DEG2RAD) / 2);
+                        const halfWidth = halfHeight * aspect;
+                        if (halfHeight <= 0 || halfWidth <= 0) {
+                            continue;
+                        }
+                        const ndcX = toPointVec.dot(right) / halfWidth;
+                        const ndcY = toPointVec.dot(up) / halfHeight;
+                        if (ndcX < -1.5 || ndcX > 1.5 || ndcY < -1.5 || ndcY > 1.5) {
+                            continue;
+                        }
+                        const screenX = (ndcX * 0.5 + 0.5) * this._width;
+                        const screenY = (-ndcY * 0.5 + 0.5) * this._height;
+                        const attenuation = item.sizeAttenuation ? Math.max(0.4, 140 / Math.max(z, 1)) : 1;
+                        const radiusPx = Math.max(0.5, item.size * attenuation);
+                        let fillStyle = baseStyle;
+                        if (colors) {
+                            const baseIndex = i;
+                            const r = THREE.MathUtils.clamp(colors[baseIndex] || 0, 0, 1);
+                            const g = THREE.MathUtils.clamp(colors[baseIndex + 1] || 0, 0, 1);
+                            const b = THREE.MathUtils.clamp(colors[baseIndex + 2] || 0, 0, 1);
+                            fillStyle = `rgba(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(b * 255)}, ${opacity})`;
+                        }
+                        ctx.beginPath();
+                        ctx.arc(screenX, screenY, radiusPx, 0, Math.PI * 2);
+                        ctx.fillStyle = fillStyle;
+                        ctx.fill();
+                    }
                 } else if (item.type === 'sprite') {
                     const material = item.object.material || new SpriteMaterial();
                     const map = material.map;


### PR DESCRIPTION
## Summary
- add BufferAttribute/BufferGeometry support and expose them on the THREE namespace
- implement PointsMaterial/Points classes plus Color.setRGB for vertex color handling
- update the custom renderer to process and draw point clouds for the starfield
- ensure the skill universe renderer's canvas stretches to fill its square container

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d1f835cd60832189dd9941b8f9c7fb