### PR TITLE
Refactor stat handling to new 0-100 model

### DIFF
--- a/__tests__/ability.test.ts
+++ b/__tests__/ability.test.ts
@@ -2,10 +2,10 @@ import { makeAbilityFromValues } from '../core/ability';
 
 describe('Ability level mapping', () => {
   it.each([
-    [{ pwr: 1, acc: 1, grt: 1, cog: 1, pln: 1, soc: 1 }, 6, 0],
-    [{ pwr: 10, acc: 10, grt: 10, cog: 10, pln: 10, soc: 10 }, 60, 47],
-    [{ pwr: 15, acc: 15, grt: 15, cog: 15, pln: 15, soc: 15 }, 90, 73],
-    [{ pwr: 20, acc: 20, grt: 20, cog: 20, pln: 20, soc: 20 }, 120, 100]
+    [{ pwr: 0, acc: 0, grt: 0, cog: 0, pln: 0, soc: 0 }, 0, 0],
+    [{ pwr: 50, acc: 50, grt: 50, cog: 50, pln: 50, soc: 50 }, 300, 50],
+    [{ pwr: 75, acc: 75, grt: 75, cog: 75, pln: 75, soc: 75 }, 450, 75],
+    [{ pwr: 100, acc: 100, grt: 100, cog: 100, pln: 100, soc: 100 }, 600, 100]
   ])('maps totals to expected 0-100 levels', (values, expectedTotal, expectedLevel) => {
     const ability = makeAbilityFromValues(values);
     expect(ability.total).toBe(expectedTotal);

--- a/core/constants.ts
+++ b/core/constants.ts
@@ -1,10 +1,8 @@
 import { UserDynamics } from './types';
 
 export const STAT_KEYS = ['pwr', 'acc', 'grt', 'cog', 'pln', 'soc'] as const;
-export const MIN_STAT = 1;
-export const MAX_STAT = 20;
-export const MIN_TOTAL = 6;
-export const MAX_TOTAL = 120;
+export const MIN_STAT = 0;
+export const MAX_STAT = 100;
 export const DEFAULT_HALF_LIFE_SAFEGUARD = 180; // days
 
 export const DEFAULT_DYNAMICS: UserDynamics = {

--- a/core/legacy.ts
+++ b/core/legacy.ts
@@ -73,7 +73,7 @@ function computePerStatShares(input: LegacyComputationInput, components: LegacyC
   const latestTotal = latestAbility?.total ?? 0;
 
   for (const key of STAT_KEYS) {
-    const base = latestStats ? latestStats[key].value : 0;
+    const base = latestStats ? latestStats[key] ?? 0 : 0;
     const load = input.trainingLoad.reduce((acc, day) => acc + (day[key] ?? 0), 0);
     const tokenQuality = input.tokens
       .filter(token => !token.statHint || token.statHint === key)

--- a/core/types.ts
+++ b/core/types.ts
@@ -1,13 +1,9 @@
 export type StatKey = 'pwr' | 'acc' | 'grt' | 'cog' | 'pln' | 'soc';
 
-export interface StatSnapshot {
-  value: number; // 1..20
-  confidence: number; // 0..1
-}
-
 export interface AbilityNow {
-  stats: Record<StatKey, StatSnapshot>;
-  total: number; // 6..120
+  stats: Record<StatKey, number>;
+  confidence: Record<StatKey, number>;
+  total: number; // 0..600
   level0to100: number; // 0..100
   progress01: number; // 0..1
 }
@@ -58,7 +54,8 @@ export interface TickInput {
 export interface TickResult {
   ability: AbilityNow;
   legacy: LegacyState;
-  updatedStats: Record<StatKey, StatSnapshot>;
+  updatedStats: Record<StatKey, number>;
+  updatedConfidence: Record<StatKey, number>;
 }
 
 export interface RecalibrationResult {


### PR DESCRIPTION
## Summary
- clamp stat values to the new 0-100 range and represent ability stats/confidence with flat records
- update dynamics computations, legacy integration, and tests to consume the flattened types
- revise ability calculations to use average-based levels without obsolete total clamping

## Testing
- npm test *(fails: jest binary unavailable because npm install is blocked by registry 403 in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3049b98808321a7f7b17f84bf4b6d