### PR TITLE
Refactor legacy tracking to per-stat counters

### DIFF
--- a/__tests__/legacy.test.ts
+++ b/__tests__/legacy.test.ts
@@ -1,0 +1,88 @@
+import { makeAbilityFromValues } from '../core/ability';
+import {
+  addLegacyProgress,
+  createEmptyLegacyState,
+  LEGACY_ROLLOVER_THRESHOLD,
+  normalizeLegacyState
+} from '../core/legacy';
+import { LegacyState } from '../core/types';
+
+function cloneLegacyState(state: LegacyState): LegacyState {
+  return normalizeLegacyState({ ...state, stats: { ...state.stats } });
+}
+
+describe('Legacy progression (Acceptance Tests §9.1–§9.4)', () => {
+  const baseAbility = makeAbilityFromValues({ pwr: 10, acc: 10, grt: 10, cog: 10, pln: 10, soc: 10 });
+
+  it('§9.1 increments a stat counter without rollover', () => {
+    const legacy = createEmptyLegacyState();
+
+    const result = addLegacyProgress({ legacy, ability: baseAbility, stat: 'pwr', amount: 250 });
+
+    expect(result.levelsGained).toBe(0);
+    expect(result.legacy.stats.pwr).toEqual({ counter: 250, level: 0, totalEarned: 250 });
+    expect(result.legacy.totalEarned).toBe(250);
+    expect(result.legacy.totalLevels).toBe(0);
+    expect(result.ability).toBe(baseAbility);
+    expect(legacy.stats.pwr.counter).toBe(0);
+  });
+
+  it('§9.2 rolls over at 1000 and bumps the matching Ability stat', () => {
+    const legacy = createEmptyLegacyState();
+    legacy.stats.pwr = { counter: 950, level: 1, totalEarned: 1950 };
+    const seededLegacy = normalizeLegacyState(legacy);
+    const ability = makeAbilityFromValues({ pwr: 15, acc: 11, grt: 11, cog: 11, pln: 11, soc: 11 });
+
+    const result = addLegacyProgress({ legacy: seededLegacy, ability, stat: 'pwr', amount: 75 });
+
+    expect(result.levelsGained).toBe(1);
+    expect(result.legacy.stats.pwr).toEqual({ counter: 25, level: 2, totalEarned: 2025 });
+    expect(result.legacy.totalLevels).toBe(2);
+    expect(result.legacy.totalEarned).toBe(2025);
+    expect(result.legacy.perkPoints).toBe(Math.floor(result.legacy.totalLevels / 5));
+    expect(result.ability.stats.pwr).toBe(ability.stats.pwr + 1);
+    expect(result.ability.total).toBe(ability.total + 1);
+  });
+
+  it('§9.3 supports multi-level rollover with carryover preserved', () => {
+    const legacy = createEmptyLegacyState();
+    legacy.stats.pwr = { counter: LEGACY_ROLLOVER_THRESHOLD - 100, level: 2, totalEarned: 2 * LEGACY_ROLLOVER_THRESHOLD + (LEGACY_ROLLOVER_THRESHOLD - 100) };
+    const seededLegacy = normalizeLegacyState(legacy);
+    const ability = makeAbilityFromValues({ pwr: 20, acc: 12, grt: 12, cog: 12, pln: 12, soc: 12 });
+
+    const result = addLegacyProgress({ legacy: seededLegacy, ability, stat: 'pwr', amount: 2500 });
+
+    const expectedCounter = (LEGACY_ROLLOVER_THRESHOLD - 100 + 2500) % LEGACY_ROLLOVER_THRESHOLD;
+    const expectedLevels = 2 + Math.floor((LEGACY_ROLLOVER_THRESHOLD - 100 + 2500) / LEGACY_ROLLOVER_THRESHOLD);
+    const expectedTotalEarned = seededLegacy.stats.pwr.totalEarned + 2500;
+
+    expect(result.levelsGained).toBe(Math.floor((LEGACY_ROLLOVER_THRESHOLD - 100 + 2500) / LEGACY_ROLLOVER_THRESHOLD));
+    expect(result.legacy.stats.pwr).toEqual({ counter: expectedCounter, level: expectedLevels, totalEarned: expectedTotalEarned });
+    expect(result.legacy.totalLevels).toBe(expectedLevels);
+    expect(result.legacy.totalEarned).toBe(expectedTotalEarned);
+    expect(result.legacy.perkPoints).toBe(Math.floor(expectedLevels / 5));
+    expect(result.ability.stats.pwr).toBe(ability.stats.pwr + result.levelsGained);
+  });
+
+  it('§9.4 isolates overflow to the targeted stat and updates atomically', () => {
+    const legacy = createEmptyLegacyState();
+    legacy.stats.pwr = { counter: 100, level: 0, totalEarned: 100 };
+    legacy.stats.acc = { counter: 400, level: 2, totalEarned: 2400 };
+    legacy.stats.grt = { counter: 10, level: 1, totalEarned: 1010 };
+    const seededLegacy = normalizeLegacyState(legacy);
+    const snapshotBefore = cloneLegacyState(seededLegacy);
+    const ability = makeAbilityFromValues({ pwr: 12, acc: 13, grt: 14, cog: 10, pln: 10, soc: 10 });
+
+    const result = addLegacyProgress({ legacy: seededLegacy, ability, stat: 'pwr', amount: 1800 });
+
+    expect(result.levelsGained).toBe(Math.floor((100 + 1800) / LEGACY_ROLLOVER_THRESHOLD));
+    expect(result.legacy.stats.acc).toEqual(snapshotBefore.stats.acc);
+    expect(result.legacy.stats.grt).toEqual(snapshotBefore.stats.grt);
+    expect(result.legacy.totalEarned).toBe(snapshotBefore.totalEarned + 1800);
+    expect(result.legacy.totalLevels).toBe(snapshotBefore.totalLevels + result.levelsGained);
+    expect(result.ability.stats.acc).toBe(ability.stats.acc);
+    expect(result.ability.stats.grt).toBe(ability.stats.grt);
+    expect(result.ability.stats.pwr).toBe(ability.stats.pwr + result.levelsGained);
+    expect(seededLegacy.stats.pwr.counter).toBe(snapshotBefore.stats.pwr.counter);
+  });
+});

--- a/core/legacy.ts
+++ b/core/legacy.ts
@@ -1,138 +1,142 @@
-import {
-  LegacyComputationInput,
-  LegacyComputationResult,
-  LegacyComponentBreakdown,
-  LegacyState,
-  StatKey
-} from './types';
-import {
-  LEGACY_LEVEL_ALPHA,
-  LEGACY_LEVEL_BASE,
-  LEGACY_WEIGHTS,
-  STAT_KEYS
-} from './constants';
+import { AbilityNow, LegacyPerStat, LegacyState, StatKey } from './types';
+import { STAT_KEYS } from './constants';
+import { calculateAbility } from './ability';
 
-function areaUnderCurve(abilityTotals: number[]): number {
-  if (abilityTotals.length <= 1) {
-    return abilityTotals[0] ?? 0;
-  }
+export const LEGACY_ROLLOVER_THRESHOLD = 1000;
 
-  let sum = 0;
-  for (let i = 1; i < abilityTotals.length; i += 1) {
-    const prev = abilityTotals[i - 1];
-    const curr = abilityTotals[i];
-    sum += (prev + curr) / 2;
-  }
-  return sum;
+function makeEmptyLegacyPerStat(): LegacyPerStat {
+  return { counter: 0, level: 0, totalEarned: 0 };
 }
 
-function computeWorkAboveMaintenance(trainingLoad: LegacyComputationInput['trainingLoad']): number {
-  let total = 0;
-  for (const day of trainingLoad) {
-    for (const key of Object.keys(day) as StatKey[]) {
-      const load = day[key] ?? 0;
-      const maintenance = 1; // heuristic until personalized thresholds are persisted client-side
-      total += Math.max(0, load - maintenance);
-    }
-  }
-  return total;
-}
-
-function computePRIndex(events: LegacyComputationInput['prEvents']): number {
-  const now = Date.now();
-  let score = 0;
-  for (const event of events) {
-    const timestamp = new Date(event.timestamp).getTime();
-    const ageDays = Math.max(0, (now - timestamp) / (1000 * 60 * 60 * 24));
-    const recencyWeight = Math.exp(-ageDays / 120);
-    score += recencyWeight * (event.weight ?? 1);
-  }
-  return score;
-}
-
-function computeConsistency(abilityHistory: LegacyComputationInput['abilityHistory']): number {
-  if (abilityHistory.length === 0) {
+function sanitizeProgressAmount(amount: number): number {
+  if (!Number.isFinite(amount)) {
     return 0;
   }
-  const window = abilityHistory.slice(-90);
-  const totals = window.map(entry => entry.total);
-  const avg = totals.reduce((acc, value) => acc + value, 0) / totals.length;
-  const variance = totals.reduce((acc, value) => acc + Math.pow(value - avg, 2), 0) / totals.length;
-  const std = Math.sqrt(variance);
-  return Math.max(0, avg - std);
+  return Math.max(0, Math.floor(amount));
 }
 
-function computeBadgeValue(badges: LegacyComputationInput['badges']): number {
-  return badges.reduce((acc, badge) => acc + Math.max(0, badge.value), 0);
-}
-
-function computePerStatShares(input: LegacyComputationInput, components: LegacyComponentBreakdown): Record<StatKey, number> {
-  const totals: Partial<Record<StatKey, number>> = {};
-  const latestAbility = input.abilityHistory[input.abilityHistory.length - 1];
-  const latestStats = latestAbility?.stats;
-  const latestTotal = latestAbility?.total ?? 0;
-
-  for (const key of STAT_KEYS) {
-    const base = latestStats ? latestStats[key] ?? 0 : 0;
-    const load = input.trainingLoad.reduce((acc, day) => acc + (day[key] ?? 0), 0);
-    const tokenQuality = input.tokens
-      .filter(token => !token.statHint || token.statHint === key)
-      .reduce((acc, token) => acc + token.quality, 0);
-    const prs = input.prEvents.filter(event => event.stat === key).length;
-    const badge = input.badges.filter(b => b.stat === key).reduce((acc, b) => acc + b.value, 0);
-
-    const totalForRatio = Math.max(1, latestTotal || base || 1);
-    const baseRatio = base / totalForRatio;
-    const legacyContribution =
-      components.auc * baseRatio * 0.3 +
-      components.work * (load / Math.max(1, input.trainingLoad.length)) * 0.25 +
-      components.pr * prs * 0.2 +
-      components.consistency * (tokenQuality / Math.max(1, input.tokens.length)) * 0.15 +
-      components.badges * badge * 0.1;
-
-    totals[key] = legacyContribution;
+function sanitizeLegacyPerStat(stat?: LegacyPerStat): LegacyPerStat {
+  if (!stat) {
+    return makeEmptyLegacyPerStat();
   }
 
-  const values = STAT_KEYS.map(key => totals[key] ?? 0);
-  const max = Math.max(...values, 1);
-  const normalized: Record<StatKey, number> = {
-    pwr: ((totals.pwr ?? 0) / max) * 100,
-    acc: ((totals.acc ?? 0) / max) * 100,
-    grt: ((totals.grt ?? 0) / max) * 100,
-    cog: ((totals.cog ?? 0) / max) * 100,
-    pln: ((totals.pln ?? 0) / max) * 100,
-    soc: ((totals.soc ?? 0) / max) * 100
-  };
+  const level = Number.isFinite(stat.level) ? Math.max(0, Math.floor(stat.level)) : 0;
+  const counter = Number.isFinite(stat.counter)
+    ? Math.max(0, Math.min(LEGACY_ROLLOVER_THRESHOLD - 1, Math.floor(stat.counter)))
+    : 0;
+  const totalEarned = Number.isFinite(stat.totalEarned)
+    ? Math.max(0, Math.floor(stat.totalEarned))
+    : level * LEGACY_ROLLOVER_THRESHOLD + counter;
 
-  return normalized;
+  return { counter, level, totalEarned };
 }
 
-export function updateLegacy(input: LegacyComputationInput): LegacyComputationResult {
-  const abilityTotals = input.abilityHistory.map(entry => entry.total);
-  const components: LegacyComponentBreakdown = {
-    auc: areaUnderCurve(abilityTotals),
-    work: computeWorkAboveMaintenance(input.trainingLoad),
-    pr: computePRIndex(input.prEvents),
-    consistency: computeConsistency(input.abilityHistory),
-    badges: computeBadgeValue(input.badges)
+export function createEmptyLegacyState(): LegacyState {
+  const stats = {} as Record<StatKey, LegacyPerStat>;
+  for (const key of STAT_KEYS) {
+    stats[key] = makeEmptyLegacyPerStat();
+  }
+  return {
+    stats,
+    totalLevels: 0,
+    totalEarned: 0,
+    perkPoints: 0
   };
+}
 
-  const weightedGain =
-    components.auc * LEGACY_WEIGHTS.auc +
-    components.work * LEGACY_WEIGHTS.work +
-    components.pr * LEGACY_WEIGHTS.pr +
-    components.consistency * LEGACY_WEIGHTS.consistency +
-    components.badges * LEGACY_WEIGHTS.badges;
+export function normalizeLegacyState(state?: LegacyState): LegacyState {
+  if (!state) {
+    return createEmptyLegacyState();
+  }
 
-  const score = Math.max(input.previousScore, input.previousScore + weightedGain);
-  const level = Math.floor(LEGACY_LEVEL_ALPHA * Math.sqrt(score / LEGACY_LEVEL_BASE));
-  const perkPoints = Math.floor(level / 5);
-  const state: LegacyState = { score, level, perkPoints };
-  const perStatShares = computePerStatShares(input, components);
+  const stats = {} as Record<StatKey, LegacyPerStat>;
+  let totalLevels = 0;
+  let totalEarned = 0;
+
+  for (const key of STAT_KEYS) {
+    const normalized = sanitizeLegacyPerStat(state.stats[key]);
+    stats[key] = normalized;
+    totalLevels += normalized.level;
+    totalEarned += normalized.totalEarned;
+  }
+
+  const perkPoints = Math.floor(totalLevels / 5);
 
   return {
-    state,
-    components,
-    perStatShares
+    stats,
+    totalLevels,
+    totalEarned,
+    perkPoints
+  };
+}
+
+export interface AddLegacyProgressInput {
+  legacy?: LegacyState;
+  ability: AbilityNow;
+  stat: StatKey;
+  amount: number;
+}
+
+export interface AddLegacyProgressResult {
+  legacy: LegacyState;
+  ability: AbilityNow;
+  levelsGained: number;
+}
+
+export function addLegacyProgress(input: AddLegacyProgressInput): AddLegacyProgressResult {
+  const baseLegacy = normalizeLegacyState(input.legacy);
+  const amount = sanitizeProgressAmount(input.amount);
+
+  if (amount <= 0) {
+    return {
+      legacy: baseLegacy,
+      ability: input.ability,
+      levelsGained: 0
+    };
+  }
+
+  const prevStat = baseLegacy.stats[input.stat];
+  const rawCounter = prevStat.counter + amount;
+  const levelsGained = Math.floor(rawCounter / LEGACY_ROLLOVER_THRESHOLD);
+  const counter = rawCounter % LEGACY_ROLLOVER_THRESHOLD;
+  const level = prevStat.level + levelsGained;
+  const totalEarned = prevStat.totalEarned + amount;
+
+  const updatedStat: LegacyPerStat = { counter, level, totalEarned };
+  const updatedStats: Record<StatKey, LegacyPerStat> = { ...baseLegacy.stats, [input.stat]: updatedStat };
+
+  let totalLevels = 0;
+  let totalEarnedAll = 0;
+  for (const key of STAT_KEYS) {
+    totalLevels += updatedStats[key].level;
+    totalEarnedAll += updatedStats[key].totalEarned;
+  }
+
+  const perkPoints = Math.floor(totalLevels / 5);
+  const legacy: LegacyState = {
+    stats: updatedStats,
+    totalLevels,
+    totalEarned: totalEarnedAll,
+    perkPoints
+  };
+
+  if (levelsGained <= 0) {
+    return {
+      legacy,
+      ability: input.ability,
+      levelsGained
+    };
+  }
+
+  const updatedAbilityStats: Record<StatKey, number> = {
+    ...input.ability.stats,
+    [input.stat]: input.ability.stats[input.stat] + levelsGained
+  };
+  const ability = calculateAbility(updatedAbilityStats, input.ability.confidence);
+
+  return {
+    legacy,
+    ability,
+    levelsGained
   };
 }

--- a/core/types.ts
+++ b/core/types.ts
@@ -8,9 +8,16 @@ export interface AbilityNow {
   progress01: number; // 0..1
 }
 
+export interface LegacyPerStat {
+  counter: number; // 0..1000 before rollover
+  level: number; // >= 0
+  totalEarned: number; // lifetime points contributed to this stat
+}
+
 export interface LegacyState {
-  score: number;
-  level: number;
+  stats: Record<StatKey, LegacyPerStat>;
+  totalLevels: number;
+  totalEarned: number;
   perkPoints: number;
 }
 
@@ -78,31 +85,6 @@ export interface RecalibrationComputationInput {
   recentAbility: AbilityNow;
   observations: DynamicsObservation[];
   prevDynamics: UserDynamics;
-}
-
-export interface LegacyComponentBreakdown {
-  auc: number;
-  work: number;
-  pr: number;
-  consistency: number;
-  badges: number;
-}
-
-export interface LegacyComputationInput {
-  abilityHistory: AbilityNow[];
-  trainingLoad: Partial<Record<StatKey, number>>[];
-  tokens: EvidenceToken[];
-  prEvents: { stat: StatKey; timestamp: string; weight?: number }[];
-  streaks: { stat: StatKey; days: number }[];
-  badges: { stat: StatKey; value: number }[];
-  previousScore: number;
-  previousLevel: number;
-}
-
-export interface LegacyComputationResult {
-  state: LegacyState;
-  components: LegacyComponentBreakdown;
-  perStatShares: Record<StatKey, number>;
 }
 
 export interface PerkDefinition {


### PR DESCRIPTION
## Summary
- rework `LegacyState` around per-stat `LegacyPerStat` records and add helper routines to normalize, rollover and award ability bumps via `addLegacyProgress`
- update the stats tick pipeline and dashboard UI to consume the new legacy shape and derive progress displays from cumulative per-stat totals
- add Jest coverage that mirrors Acceptance Tests §9.1–§9.4 for counter increments, rollovers, multi-level carryover, and isolation of overflow updates

## Testing
- npm test *(fails: jest not installed because dependencies cannot be downloaded in this environment)*


------
https://chatgpt.com/codex/tasks/task_e_68d309423f54832196038749bb19a843