### PR TITLE
Fix authentication script initialization errors

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -368,15 +368,16 @@ function updatePerkProgressionMeters(summary) {
     })();
 
     const shardGoal = LEGACY_ROLLOVER_THRESHOLD;
-    const rawStatsTowardPerk = typeof characterData?.statCounter === 'number' && Number.isFinite(characterData.statCounter)
-        ? Math.max(0, Math.floor(characterData.statCounter))
-        : 0;
+    const rawStatsTowardPerk = (() => {
+        if (typeof characterData?.statCounter === 'number' && Number.isFinite(characterData.statCounter)) {
+            return Math.max(0, Math.floor(characterData.statCounter));
+        }
+        if (typeof characterData?.legacyStatProgress === 'number' && Number.isFinite(characterData.legacyStatProgress)) {
+            return Math.max(0, Math.floor(characterData.legacyStatProgress));
+        }
+        return 0;
+    })();
     const statsTowardPerk = rawStatsTowardPerk % STATS_PER_PERK_POINT;
-    const rawStatsTowardPerk = typeof characterData?.legacyStatProgress === 'number' && Number.isFinite(characterData.legacyStatProgress)
-        ? Math.max(0, Math.floor(characterData.legacyStatProgress))
-        : 0;
-    const perkStatGoal = 10;
-    const statsTowardPerk = rawStatsTowardPerk % perkStatGoal;
     setPerkProgressMeter(
         'perk-progress-chores-bar',
         'perk-progress-chores-text',
@@ -386,8 +387,9 @@ function updatePerkProgressionMeters(summary) {
             const statLabel = shardProgress.statKey
                 ? getModernStatShortLabel(shardProgress.statKey)
                 : 'STAT';
-            return `${Math.round(current)} / ${goal.toLocaleString()} legacy shards toward next ${statLabel} stat. Stat counter: ${statsTowardPerk} / ${STATS_PER_PERK_POINT}.`;
-            return `${Math.round(current)} / ${goal.toLocaleString()} legacy shards toward next ${statLabel} stat. ${statsTowardPerk} / ${perkStatGoal} stats toward next perk point.`;
+            const shardProgressText = `${Math.round(current)} / ${goal.toLocaleString()} legacy shards toward next ${statLabel} stat.`;
+            const perkProgressText = `${statsTowardPerk} / ${STATS_PER_PERK_POINT} stats toward next perk point.`;
+            return `${shardProgressText} ${perkProgressText}`;
         }
     );
 
@@ -1183,23 +1185,10 @@ let choreManager = {
                 characterData.skillPoints = existingSkillPoints + perkPointsFromStats;
                 const perkPlural = perkPointsFromStats === 1 ? 'Perk Point' : 'Perk Points';
                 showToast(`Legacy ascension! +${perkPointsFromStats} ${perkPlural}.`);
-            const currentLegacyStatProgress = typeof characterData.legacyStatProgress === 'number' && Number.isFinite(characterData.legacyStatProgress)
-                ? characterData.legacyStatProgress
-                : 0;
-            const updatedLegacyStatProgress = currentLegacyStatProgress + pointsGained;
-            characterData.legacyStatProgress = updatedLegacyStatProgress;
-
-            const perkPointsFromShards = Math.floor(updatedLegacyStatProgress / 10);
-            if (perkPointsFromShards > 0) {
-                characterData.legacyStatProgress = updatedLegacyStatProgress % 10;
-                const existingSkillPoints = typeof characterData.skillPoints === 'number' && Number.isFinite(characterData.skillPoints)
-                    ? characterData.skillPoints
-                    : 0;
-                characterData.skillPoints = existingSkillPoints + perkPointsFromShards;
-                const perkPlural = perkPointsFromShards === 1 ? 'Perk Point' : 'Perk Points';
-                showToast(`Legacy ascension! +${perkPointsFromShards} ${perkPlural}.`);
                 refreshStarAvailability();
             }
+
+            characterData.legacyStatProgress = characterData.statCounter;
         }
 
         this.chores.splice(choreIndex, 1);
@@ -1301,9 +1290,7 @@ async function loadData(userId) {
             statsToNextLevel: loadedCharacterData.statsToNextLevel || 10,
             skillPoints: loadedCharacterData.skillPoints || 0,
             statCounter: normalizedStatCounter,
-            legacyStatProgress: typeof sanitizedLoadedData.legacyStatProgress === 'number' && Number.isFinite(sanitizedLoadedData.legacyStatProgress)
-                ? Math.max(0, Math.floor(sanitizedLoadedData.legacyStatProgress))
-                : 0,
+            legacyStatProgress: normalizedStatCounter,
             legacy: normalizeLegacyState(loadedCharacterData.legacy),
             statConfidence: loadedCharacterData.statConfidence || {},
             recentTrainingLoad: loadedCharacterData.recentTrainingLoad || {},


### PR DESCRIPTION
## Summary
- avoid duplicate perk progress variables so authentication handlers are registered successfully
- keep `legacyStatProgress` synchronized with the normalized stat counter when loading and updating data
- update perk progress messaging to report both shard and perk-point progress without breaking script execution

## Testing
- npm test *(fails: pre-existing failing dynamics/ui suites in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d33328fef08321a37a4d3393f3f583