### PR TITLE
Fix duplicate perk progression stat calculation

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -368,16 +368,18 @@ function updatePerkProgressionMeters(summary) {
     })();
 
     const shardGoal = LEGACY_ROLLOVER_THRESHOLD;
-    const rawStatsTowardPerk = (() => {
+    const statsTowardPerk = (() => {
         if (typeof characterData?.statCounter === 'number' && Number.isFinite(characterData.statCounter)) {
-            return Math.max(0, Math.floor(characterData.statCounter));
+            return Math.max(0, Math.floor(characterData.statCounter)) % STATS_PER_PERK_POINT;
         }
-        if (typeof characterData?.legacyStatProgress === 'number' && Number.isFinite(characterData.legacyStatProgress)) {
-            return Math.max(0, Math.floor(characterData.legacyStatProgress));
+        if (
+            typeof characterData?.legacyStatProgress === 'number'
+            && Number.isFinite(characterData.legacyStatProgress)
+        ) {
+            return Math.max(0, Math.floor(characterData.legacyStatProgress)) % STATS_PER_PERK_POINT;
         }
         return 0;
     })();
-    const statsTowardPerk = rawStatsTowardPerk % STATS_PER_PERK_POINT;
     setPerkProgressMeter(
         'perk-progress-chores-bar',
         'perk-progress-chores-text',


### PR DESCRIPTION
## Summary
- compute perk progression remainder directly in the existing helper instead of declaring a second `rawStatsTowardPerk` constant
- ensure the perk progress text continues to reflect the stats remaining toward the next perk point

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3361cd1688321ad3930e8419b446f