### PR TITLE
Revise perk progression layout

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -935,6 +935,28 @@ model-viewer.avatar-viewer {
     color: var(--color-primary-dark);
 }
 
+.perk-progress-overview {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 12px;
+}
+
+.perk-overview-card {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 12px 14px;
+    border-radius: 16px;
+    background: rgba(63, 111, 118, 0.08);
+    border: 1px solid rgba(63, 111, 118, 0.12);
+}
+
+.perk-overview-card strong,
+.perk-overview-value {
+    font-size: 1.2em;
+    color: var(--color-primary-dark);
+}
+
 .perk-progress-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));

--- a/__tests__/ui.test.ts
+++ b/__tests__/ui.test.ts
@@ -1,5 +1,9 @@
 import { readFileSync } from 'fs';
-import { JSDOM } from 'jsdom';
+
+// jsdom does not ship TypeScript definitions in this project configuration.
+// Using require keeps the dependency untyped for the purposes of these DOM smoke tests.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { JSDOM } = require('jsdom');
 
 describe('stat row layout', () => {
   const html = readFileSync('index.html', 'utf-8');
@@ -7,11 +11,11 @@ describe('stat row layout', () => {
   const document = dom.window.document;
 
   it('renders six stat rows with major and legacy bars', () => {
-    const statRows = Array.from(document.querySelectorAll('.stat-row'));
+    const statRows = Array.from(document.querySelectorAll('.stat-row')) as any[];
     expect(statRows).toHaveLength(6);
     statRows.forEach(row => {
-      const major = row.querySelector('.stat-bar.major');
-      const legacy = row.querySelector('.stat-bar.legacy');
+      const major = (row as any).querySelector('.stat-bar.major');
+      const legacy = (row as any).querySelector('.stat-bar.legacy');
       expect(major).not.toBeNull();
       expect(legacy).not.toBeNull();
       if (major) {
@@ -21,5 +25,14 @@ describe('stat row layout', () => {
         expect(legacy.classList.contains('legacy')).toBe(true);
       }
     });
+  });
+
+  it('includes perk progression overview metrics with unique identifiers', () => {
+    expect(document.getElementById('perk-character-level')).not.toBeNull();
+    expect(document.getElementById('perk-stats-to-next')).not.toBeNull();
+    expect(document.getElementById('perk-leading-stat')).not.toBeNull();
+
+    expect(document.querySelectorAll('#perk-progress-legacy-bar')).toHaveLength(1);
+    expect(document.querySelectorAll('#perk-progress-legacy-text')).toHaveLength(1);
   });
 });

--- a/index.html
+++ b/index.html
@@ -176,18 +176,27 @@
                     <span class="meta-label">Perk Points Available</span>
                     <strong id="perk-points-available">0</strong>
                 </div>
+                <div class="perk-progress-overview" role="group" aria-label="Perk progression indicators">
+                    <div class="perk-overview-card">
+                        <span class="meta-label">Character Level</span>
+                        <strong id="perk-character-level">0</strong>
+                    </div>
+                    <div class="perk-overview-card">
+                        <span class="meta-label">Stats Toward Next Perk Point</span>
+                        <span id="perk-stats-to-next" class="perk-overview-value">0 / 10</span>
+                    </div>
+                    <div class="perk-overview-card">
+                        <span class="meta-label">Leading Legacy Stat</span>
+                        <span id="perk-leading-stat" class="perk-overview-value">--</span>
+                    </div>
+                </div>
                 <div class="perk-progress-grid">
                     <div class="perk-progress-card">
-                        <h4>Stat Counter</h4>
-                        <div class="progress-bar-container">
-                            <div class="progress-bar" id="perk-progress-chores-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
-                        </div>
-                        <p id="perk-progress-chores-text" class="perk-progress-text">0 / 1,000 legacy shards toward next stat. Stat counter: 0 / 10.</p>
                         <h4>Legacy Shards</h4>
                         <div class="progress-bar-container">
-                            <div class="progress-bar" id="perk-progress-chores-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
+                            <div class="progress-bar" id="perk-progress-legacy-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
                         </div>
-                        <p id="perk-progress-chores-text" class="perk-progress-text">0 / 1,000 legacy shards toward next stat. 0 / 10 stats toward next perk point.</p>
+                        <p id="perk-progress-legacy-text" class="perk-progress-text">0 / 1,000 legacy shards toward next stat milestone.</p>
                     </div>
                     <div class="perk-progress-card">
                         <h4>Quarterly</h4>


### PR DESCRIPTION
## Summary
- restructure the perk progression summary to show level, stat progress, and the leading legacy stat with unique identifiers
- update the perk progression updater to feed the new indicators from normalized legacy data and refreshed progress bar ids
- extend styling and ui coverage to accommodate the new perk overview layout

## Testing
- npx jest __tests__/ui.test.ts --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d33e0419ec8321ab2b0979ef4f455f