### PR TITLE
Add Sponsored Star Links documentation pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Codex Vitae — Sponsored Star Links (Documentation Pack)
+
+This bundle documents the **Sponsored Star Links** revenue feature. It is designed to be pasted into your repository and referenced by both product and engineering. All files are Markdown, ready for GitHub rendering.
+
+## Contents
+- Policy & UX principles → `docs/policies/sponsored-star-links-policy.md`
+- Partner-facing one-pager → `docs/partners/sponsor-one-pager.md`
+- Creative specs (partners) → `docs/partners/creative-specs.md`
+- Pricing models (internal + shareable) → `docs/partners/pricing-models.md`
+- Ad tech spec (engineering) → `docs/tech/ad-tech-spec.md`
+
+## How this fits the codebase
+- Stars have a **Detail Panel**. This pack defines a dedicated **Sponsored options** block with hard caps (e.g., max 3).
+- **Neutrality** is enforced in code: sponsors do not affect Star requirements or ranking of organic options.
+- **Privacy**: share only aggregate metrics with sponsors by default; personal data requires explicit user consent.
+- **Extensibility**: pricing, geo targeting, and format are data-driven via a `sponsored_links` subdocument per Star.
+
+## Quick integration pointers
+- Frontend: add a `SponsoredSection` component (lazy-loaded), with `isSponsored` labeling and CTA buttons.
+- Backend: add `sponsor_campaigns` collection and `star_sponsored_links` mapping; sanitize and validate all fields.
+- Attribution: support UTM params and optional postback webhook; never block Star completion on sponsor availability.
+
+---
+
+© Codex Vitae

--- a/docs/partners/creative-specs.md
+++ b/docs/partners/creative-specs.md
@@ -1,0 +1,17 @@
+# Creative Specs (Sponsored Star Links)
+
+## Assets
+- **Title:** ≤ 40 characters (e.g., “Certified English in 8 Weeks”)
+- **Subtitle:** ≤ 80 characters (benefit + differentiator)
+- **Logo:** 512×512 PNG or SVG (transparent background preferred)
+- **CTA:** “Start Course,” “Get Certified,” “Try Free,” etc.
+- **URL:** HTTPS landing page with **UTM parameters** provided by Codex Vitae
+
+## Copy guidelines
+- Be clear and outcome-oriented; avoid jargon.
+- No misleading claims (no “guaranteed outcomes”).
+- Avoid aggressive scarcity or dark patterns.
+
+## Review & updates
+- We review creatives within 2 business days.
+- You can request copy/logo updates at any time.

--- a/docs/partners/pricing-models.md
+++ b/docs/partners/pricing-models.md
@@ -1,0 +1,23 @@
+# Pricing Models (Sponsored Star Links)
+
+Choose the model that fits your goals. We can mix-and-match during pilots.
+
+## 1) Flat Monthly (per Star)
+- **Best for:** Brand presence and predictable spend
+- **Billing:** Fixed monthly per selected Star(s)
+- **Notes:** Easy to plan; limited performance risk
+
+## 2) CPC (Cost Per Click)
+- **Best for:** Traffic acquisition
+- **Billing:** Pay per click recorded by our platform
+- **Notes:** Requires UTM tracking; fraud checks applied
+
+## 3) CPA (Cost Per Action / Enrollment)
+- **Best for:** Direct enrollments
+- **Billing:** Pay per verified enrollment (postback or webhook)
+- **Notes:** Needs conversion tracking integration
+
+## 4) Bundles
+- **Best for:** Broader coverage
+- **Billing:** Flat or hybrid pricing for Constellations or Galaxies
+- **Notes:** Discount tiers based on scope and term

--- a/docs/partners/sponsor-one-pager.md
+++ b/docs/partners/sponsor-one-pager.md
@@ -1,0 +1,48 @@
+# Codex Vitae — Sponsored Star Links (Partner One-Pager)
+
+**Reach high-intent users** at the exact moment they’re completing a milestone “Star” (e.g., English Speaking, 5K Run, Portfolio Project). Your brand appears inside the Star detail panel.
+
+## Why sponsor a Star?
+- **High intent:** Users are actively completing a requirement your product can fulfill.
+- **Clean UX:** Clearly labeled Sponsored section—no clutter, no bait-and-switch.
+- **Trust-first design:** Neutral ranking, user choice, and transparent labeling.
+
+## Placement
+- **Location:** Star Detail panel → “Sponsored options” block (max 3 slots).
+- **Format:** Title, short value prop (≤80 chars), CTA button, optional rating badge/logo.
+
+## Targeting
+- **Contextual:** Only on relevant Stars (e.g., English providers on “English Speaking Star”).
+- **Geo/language:** Regional targeting by country/language where available.
+- **Audience fit:** Hobbyists, students, professionals upskilling—self-selected via Star choice.
+
+## Pricing Options
+- **Flat Monthly (per Star):** Simple, predictable. Great for pilots.
+- **CPC / CPA:** Pay per click or per verified enrollment (requires postback/attribution).
+- **Bundles:** Constellation or Galaxy packages for broader coverage.
+
+See also: `creative-specs.md` and `pricing-models.md`.
+
+## Measurement & Reporting
+- **Metrics:** Impressions, clicks, CTR, estimated conversions (if integrated), and top geos.
+- **Attribution:** Optional conversion postback/webhook; standard UTM tracking supported.
+- **Optimization:** A/B test copy and CTA; rotate creatives on request.
+
+## Quality & Eligibility
+- Accreditation or reputable reviews (where applicable).
+- Clear refund/cancellation policy on landing page.
+- No misleading claims (e.g., guaranteed outcomes, fake scarcity).
+
+## Brand & Safety
+- Family-friendly creatives; no hate, harassment, or adult content.
+- Compliant with regional advertising laws and platform policies.
+- We may pause or remove campaigns that harm user trust or violate guidelines.
+
+## Next Steps
+1. **Choose Stars** relevant to your offering.
+2. **Select pricing** (Flat, CPC/CPA, or Bundle).
+3. **Send creatives & tracking** (logo, copy, URL with UTMs; optional postback).
+4. **Go live** after approval.
+
+**Contact:** partnerships@codexvitae.app  
+**Media kit & inventory:** Available upon request.

--- a/docs/policies/sponsored-star-links-policy.md
+++ b/docs/policies/sponsored-star-links-policy.md
@@ -1,0 +1,28 @@
+# Sponsored Star Links — Policy (Ad Labeling & Neutrality)
+
+## What are Sponsored Star Links?
+Some Stars include clearly labeled **Sponsored** links from providers (e.g., courses, apps, schools) who pay for placement on that Star’s detail panel.
+
+## Neutrality & user choice
+- Sponsored links **never** change a Star’s requirements.
+- Users **never** have to use a sponsor to unlock a Star.
+- Every Star with sponsors also shows **non-sponsored** options and a **“Bring your own proof”** path.
+
+## Labeling & placement
+- Sponsored links appear in a separate, clearly labeled section: **“Sponsored options.”**
+- Organic recommendations are listed **independently** and based on relevance.
+- We cap sponsored slots to keep the interface clean (default: **max 3**).
+
+## Privacy & data use
+- We **do not** share personal data with sponsors without explicit consent.
+- Sponsors receive only **aggregate metrics** (impressions, clicks, conversions if integrated).
+- Users can manage ad preferences in **Settings → Sponsored Links**.
+
+## Conflicts & eligibility
+- Sponsors cannot influence Star criteria, outcomes, or user rankings.
+- Baseline quality required (e.g., accreditation or consistently positive reviews).
+- We may refuse or remove sponsors that violate brand or safety standards.
+
+## Creator controls
+- Constellation/Star creators can opt-in/out of sponsor slots for their content.
+- If all sponsors are disabled, the block is hidden and organic recommendations remain.

--- a/docs/tech/ad-tech-spec.md
+++ b/docs/tech/ad-tech-spec.md
@@ -1,0 +1,53 @@
+# Ad Tech Spec — Sponsored Star Links (Engineering)
+
+This document specifies data structures, APIs, and UI integration for Sponsored Star Links.
+
+## Data Model (Firestore)
+- `sponsor_campaigns/{campaignId}`
+  - `name` (string)
+  - `status` (enum: ACTIVE, PAUSED, ENDED)
+  - `targeting` (object): `{ galaxies:[], constellations:[], stars:[], countries:[], languages:[] }`
+  - `pricing` (object): `{ model: 'FLAT'|'CPC'|'CPA'|'BUNDLE', terms:{} }`
+  - `creatives` (object): `{ title, subtitle, logoUrl, ctaLabel, landingUrl, utm: { source, medium, campaign } }`
+  - `brand_safety` (object): `{ verified: bool, notes: string }`
+  - `createdAt`, `updatedAt` (timestamps)
+
+- `star_sponsored_links/{starId}`
+  - `slots` (array, max 3): list of `{ campaignId, slotIndex, startAt, endAt }`
+  - `showSponsored` (bool, default true)
+  - `creatorOptOut` (bool, default false)
+
+- `ad_events/{eventId}`
+  - `type` (enum: IMPRESSION|CLICK|CONVERSION)
+  - `campaignId`, `starId`, `userId?` (if consent), `geo?`
+  - `ts` (timestamp), `meta` (object)
+
+## APIs (Express/Firebase Functions)
+- `GET /api/sponsor/slots?starId=...`
+  - Returns up to 3 active slots with creative payloads (server-side filtered by targeting)
+- `POST /api/sponsor/event`
+  - Body: `{ type, campaignId, starId, meta }`
+  - Records IMPRESSION/CLICK; for CONVERSION, requires signed webhook or OAuth app link
+
+## Frontend (Web)
+- Component: `<SponsoredOptions starId="...">`
+  - Lazy load on Star Detail open
+  - Render **Sponsored** badge; enforce `maxSlots=3`
+  - CTAs open `landingUrl` with appended UTMs
+  - Fire `IMPRESSION` on mount; `CLICK` on CTA
+  - Respect `creatorOptOut` and `showSponsored` flags
+
+## Privacy & Consent
+- Default analytics: aggregate only (no PII)
+- Personalization/PII events require explicit consent; gate with a settings toggle
+- Provide “Why am I seeing this?” link to policy
+
+## Testing
+- Unit: data validation, slot selection logic, UTM builder
+- Integration: event pipeline, rate limiting, deduping
+- E2E: Star Detail → Sponsored display → click tracking → (optional) conversion postback
+
+## Admin Console (MVP)
+- Upload creatives, set targeting, choose pricing model
+- Schedule slots (start/end)
+- Basic reporting: impressions, clicks, CTR by Star/geo


### PR DESCRIPTION
## Summary
- add repository README describing the Sponsored Star Links documentation bundle and integration pointers
- document Sponsored Star Links policies, partner materials, pricing, creative specs, and engineering requirements

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3436615708321aae62a779ef33595