### PR TITLE
Simplify perk progression display

### DIFF
--- a/__tests__/ui.test.ts
+++ b/__tests__/ui.test.ts
@@ -28,11 +28,10 @@ describe('stat row layout', () => {
   });
 
   it('includes perk progression overview metrics with unique identifiers', () => {
-    expect(document.getElementById('perk-character-level')).not.toBeNull();
     expect(document.getElementById('perk-stats-to-next')).not.toBeNull();
-    expect(document.getElementById('perk-leading-stat')).not.toBeNull();
-
-    expect(document.querySelectorAll('#perk-progress-legacy-bar')).toHaveLength(1);
-    expect(document.querySelectorAll('#perk-progress-legacy-text')).toHaveLength(1);
+    expect(document.querySelectorAll('#perk-progress-quarterly-bar')).toHaveLength(1);
+    expect(document.querySelectorAll('#perk-progress-quarterly-text')).toHaveLength(1);
+    expect(document.querySelectorAll('#perk-progress-yearly-bar')).toHaveLength(1);
+    expect(document.querySelectorAll('#perk-progress-yearly-text')).toHaveLength(1);
   });
 });

--- a/index.html
+++ b/index.html
@@ -196,35 +196,20 @@
                 </div>
                 <div class="perk-progress-overview" role="group" aria-label="Perk progression indicators">
                     <div class="perk-overview-card">
-                        <span class="meta-label">Character Level</span>
-                        <strong id="perk-character-level">0</strong>
-                    </div>
-                    <div class="perk-overview-card">
-                        <span class="meta-label">Stats Toward Next Perk Point</span>
+                        <span class="meta-label">Stats Toward Next Point</span>
                         <span id="perk-stats-to-next" class="perk-overview-value">0 / 10</span>
-                    </div>
-                    <div class="perk-overview-card">
-                        <span class="meta-label">Leading Legacy Stat</span>
-                        <span id="perk-leading-stat" class="perk-overview-value">--</span>
                     </div>
                 </div>
                 <div class="perk-progress-grid">
                     <div class="perk-progress-card">
-                        <h4>Legacy Shards</h4>
-                        <div class="progress-bar-container">
-                            <div class="progress-bar" id="perk-progress-legacy-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
-                        </div>
-                        <p id="perk-progress-legacy-text" class="perk-progress-text">0 / 1,000 legacy shards toward next stat milestone.</p>
-                    </div>
-                    <div class="perk-progress-card">
-                        <h4>Quarterly</h4>
+                        <h4>Quarterly Progression</h4>
                         <div class="progress-bar-container">
                             <div class="progress-bar" id="perk-progress-quarterly-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
                         </div>
                         <p id="perk-progress-quarterly-text" class="perk-progress-text">0 / 60 days logged this quarter.</p>
                     </div>
                     <div class="perk-progress-card">
-                        <h4>Yearly</h4>
+                        <h4>Annual Progression</h4>
                         <div class="progress-bar-container">
                             <div class="progress-bar" id="perk-progress-yearly-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
                         </div>

--- a/js/main.js
+++ b/js/main.js
@@ -449,14 +449,6 @@ function setPerkProgressMeter(barId, textId, current, goal, textFormatter) {
 
 function updatePerkProgressionMeters(summary) {
     const normalizedLegacy = normalizeLegacyState(characterData?.legacy);
-    const characterLevel = typeof characterData?.level === 'number' && Number.isFinite(characterData.level)
-        ? Math.max(1, Math.floor(characterData.level))
-        : Math.max(1, Math.floor(normalizedLegacy.totalLevels) || 1);
-    const levelElement = document.getElementById('perk-character-level');
-    if (levelElement) {
-        levelElement.textContent = characterLevel.toString();
-    }
-
     const totalStatIncreases = Math.max(0, Math.floor(normalizedLegacy.totalLevels));
     const statsTowardPerk = totalStatIncreases % STATS_PER_PERK_POINT;
     const statsProgressElement = document.getElementById('perk-stats-to-next');
@@ -471,49 +463,6 @@ function updatePerkProgressionMeters(summary) {
         const legacyStat = normalizedLegacy.stats[statKey] || createEmptyLegacyStat();
         characterData.choreProgress[statKey] = legacyStat.counter;
     });
-
-    const shardProgress = (() => {
-        let leadingStat = null;
-        let leadingValue = 0;
-        Object.entries(normalizedLegacy.stats).forEach(([statKey, legacyStat]) => {
-            const counter = typeof legacyStat?.counter === 'number' && Number.isFinite(legacyStat.counter)
-                ? Math.max(0, legacyStat.counter)
-                : 0;
-            if (counter > leadingValue) {
-                leadingValue = counter;
-                leadingStat = statKey;
-            }
-        });
-        return { statKey: leadingStat, value: leadingValue };
-    })();
-
-    const leadingStatLabel = shardProgress.statKey
-        ? getModernStatShortLabel(shardProgress.statKey)
-        : null;
-    const leadingStatElement = document.getElementById('perk-leading-stat');
-    if (leadingStatElement) {
-        if (leadingStatLabel) {
-            const shardValue = Math.round(shardProgress.value);
-            leadingStatElement.textContent = `${leadingStatLabel} • ${shardValue.toLocaleString()} / ${LEGACY_ROLLOVER_THRESHOLD.toLocaleString()}`;
-        } else {
-            leadingStatElement.textContent = '--';
-        }
-    }
-
-    const shardGoal = LEGACY_ROLLOVER_THRESHOLD;
-    setPerkProgressMeter(
-        'perk-progress-legacy-bar',
-        'perk-progress-legacy-text',
-        shardProgress.value,
-        shardGoal,
-        (current, goal) => {
-            const shardProgressText = leadingStatLabel
-                ? `${Math.round(current)} / ${goal.toLocaleString()} legacy shards toward next ${leadingStatLabel} stat.`
-                : `${Math.round(current)} / ${goal.toLocaleString()} legacy shards logged.`;
-            const perkProgressText = `${statsTowardPerk} / ${STATS_PER_PERK_POINT} stat increases counted toward next perk point.`;
-            return `${shardProgressText} ${perkProgressText}`;
-        }
-    );
 
     const currentQuarterId = getQuarterIdentifier(new Date());
     const hasQuarterData = currentQuarterId


### PR DESCRIPTION
## Summary
- remove the character level, leading stat, and legacy shard UI elements from the perk progression panel
- update perk meter logic to focus on stat, quarterly, and annual progress indicators
- refresh DOM smoke tests to cover the simplified perk progression layout

## Testing
- npm test *(fails: dynamics tests already exceeding tolerances in baseline)*

------
https://chatgpt.com/codex/tasks/task_e_68d34701736083219938ef9196f86e42