### PR TITLE
Fix syntax error blocking auth actions and skill universe

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -568,7 +568,6 @@ function updatePerkProgressionMeters(summary) {
         levelElement.textContent = characterLevel.toString();
     }
 
-    const totalStatIncreases = Math.max(0, Math.floor(normalizedLegacy.totalLevels));
     const statsTowardPerk = totalStatIncreases % STATS_PER_PERK_POINT;
     const statsProgressElement = document.getElementById('perk-stats-to-next');
     if (statsProgressElement) {


### PR DESCRIPTION
## Summary
- remove the duplicate `totalStatIncreases` declaration in `updatePerkProgressionMeters`
- allow the script to initialize authentication handlers and the skill universe renderer again

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d34d84accc83219caf65443120a38b