### PR TITLE
Add plane geometry support to Skill Universe renderer

### DIFF
--- a/js/vendor/three.min.js
+++ b/js/vendor/three.min.js
@@ -478,6 +478,15 @@
         }
     }
 
+    class PlaneGeometry extends Geometry {
+        constructor(width = 1, height = 1) {
+            super();
+            this.type = 'PlaneGeometry';
+            this.parameters.width = width;
+            this.parameters.height = height;
+        }
+    }
+
     class Material {
         constructor(params = {}) {
             this.transparent = !!params.transparent;
@@ -653,6 +662,8 @@
     THREE.SphereGeometry = SphereGeometry;
     THREE.IcosahedronGeometry = IcosahedronGeometry;
     THREE.RingGeometry = RingGeometry;
+    THREE.PlaneGeometry = PlaneGeometry;
+    THREE.PlaneBufferGeometry = PlaneGeometry;
     THREE.Material = Material;
     THREE.MeshStandardMaterial = MeshStandardMaterial;
     THREE.MeshBasicMaterial = MeshBasicMaterial;
@@ -940,6 +951,38 @@
                             distance,
                             worldPosition
                         };
+                    } else if (geometry.type === 'PlaneGeometry') {
+                        const widthParam = params.width !== undefined ? params.width : 1;
+                        const heightParam = params.height !== undefined ? params.height : 1;
+                        const halfWidthWorld = Math.abs(widthParam * scale.x) * 0.5;
+                        const halfHeightWorld = Math.abs(heightParam * scale.y) * 0.5;
+                        const widthNDC = halfWidthWorld / halfWidth;
+                        const heightNDC = halfHeightWorld / halfHeight;
+                        const halfWidthPx = Math.abs(widthNDC) * this._width * 0.5;
+                        const halfHeightPx = Math.abs(heightNDC) * this._height * 0.5;
+                        items.push({
+                            object,
+                            type: 'plane',
+                            screenX,
+                            screenY,
+                            halfWidthPx,
+                            halfHeightPx,
+                            widthNDC,
+                            heightNDC,
+                            ndcX,
+                            ndcY,
+                            ndcZ: z,
+                            distance,
+                            renderOrder: object.renderOrder || 0
+                        });
+                        entry = {
+                            type: 'sphere',
+                            ndcX,
+                            ndcY,
+                            radiusNDC: Math.max(Math.abs(widthNDC), Math.abs(heightNDC)),
+                            distance,
+                            worldPosition
+                        };
                     } else {
                         const radius = (params.radius || 1) * (scale.x + scale.y + scale.z) / 3;
                         const radiusNDC = radius / halfHeight;
@@ -1028,6 +1071,30 @@
                     ctx.globalAlpha = opacity;
                     ctx.fill();
                     ctx.globalAlpha = 1;
+                } else if (item.type === 'plane') {
+                    const material = item.object.material || new MeshBasicMaterial();
+                    const opacity = material.transparent ? material.opacity : 1;
+                    const color = material.color ? material.color.clone() : new Color(0xffffff);
+                    const widthPx = Math.max(0, item.halfWidthPx);
+                    const heightPx = Math.max(0, item.halfHeightPx);
+                    ctx.save();
+                    ctx.globalAlpha = opacity;
+                    ctx.beginPath();
+                    ctx.ellipse(item.screenX, item.screenY, widthPx, heightPx, 0, 0, Math.PI * 2);
+                    ctx.clip();
+                    if (material.map && material.map.image) {
+                        ctx.drawImage(
+                            material.map.image,
+                            item.screenX - widthPx,
+                            item.screenY - heightPx,
+                            widthPx * 2,
+                            heightPx * 2
+                        );
+                    } else {
+                        ctx.fillStyle = color.getStyle(opacity);
+                        ctx.fill();
+                    }
+                    ctx.restore();
                 } else if (item.type === 'points') {
                     const positions = item.positions || [];
                     if (!positions.length) {


### PR DESCRIPTION
## Summary
- add a lightweight PlaneGeometry implementation to the custom Three.js shim and export it for consumers
- extend the renderer to handle plane meshes by projecting them as ellipses and clipping textures so galaxy discs render again

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3dcfa986083218fdf0337e1c34b53