### PR TITLE
Patch THREE vendor color implementation to support lerp

### DIFF
--- a/js/vendor/three.min.js
+++ b/js/vendor/three.min.js
@@ -222,6 +222,14 @@
             c.b = this.b;
             return c;
         }
+        lerp(color, alpha = 0) {
+            const target = color instanceof Color ? color : new Color(color ?? 0xffffff);
+            const t = Number.isFinite(alpha) ? Math.max(0, Math.min(1, alpha)) : 0;
+            this.r += (target.r - this.r) * t;
+            this.g += (target.g - this.g) * t;
+            this.b += (target.b - this.b) * t;
+            return this;
+        }
         add(color) {
             this.r += color.r;
             this.g += color.g;


### PR DESCRIPTION
## Summary
- extend the lightweight THREE.js vendor build with a Color.prototype.lerp helper so cloned colors can blend correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d42698306083219203179d60bde175