### PR TITLE
Fix avatar stage markup to restore layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,23 +50,6 @@
                     alt="Avatar placeholder"
                     decoding="async"
                 />
-            <div class="avatar-stage is-placeholder">
-                <img
-                    id="captured-photo"
-                    class="avatar-placeholder"
-                    src="assets/avatars/codex-vitae-avatar-placeholder.svg"
-                    alt="Avatar placeholder"
-                    decoding="async"
-                />
-            <div class="avatar-stage is-placeholder">
-                <img
-                    id="captured-photo"
-                    class="avatar-placeholder"
-                    src="assets/avatars/avatar-placeholder-casual-park.jpg"
-                    src="assets/avatars/codex-vitae-avatar-placeholder.svg"
-                    alt="Avatar placeholder"
-                    decoding="async"
-                />
                 <video id="webcam-feed" class="avatar-camera hidden" autoplay playsinline></video>
             </div>
             <canvas id="photo-canvas" class="hidden"></canvas>


### PR DESCRIPTION
## Summary
- remove duplicate nested avatar-stage containers that trapped the rest of the UI inside the avatar widget
- restore the intended placeholder image/video pairing so the layout renders correctly again

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4654725f083219be26555a6d4bb92