### PR TITLE
Replace avatar placeholder with park illustration

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -368,16 +368,11 @@ button:active {
 
 .avatar-stage img.avatar-placeholder {
     object-fit: cover;
-    object-position: 50% 10%;
+    object-position: center;
     padding: 0;
     box-sizing: border-box;
     background: transparent;
     filter: none;
-    object-fit: contain;
-    padding: 8% 10% 6%;
-    box-sizing: border-box;
-    background: radial-gradient(circle at 50% 30%, rgba(255, 255, 255, 0.8), rgba(216, 230, 241, 0));
-    filter: drop-shadow(0 18px 34px rgba(68, 104, 132, 0.28));
 }
 
 .avatar-stage > * {

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
                 <img
                     id="captured-photo"
                     class="avatar-placeholder"
-                    src="assets/avatars/codex-vitae-avatar-placeholder.svg"
+                    src="assets/avatars/avatar-placeholder-casual-park.jpg"
                     alt="Avatar placeholder"
                     decoding="async"
                 />

--- a/js/main.js
+++ b/js/main.js
@@ -39,14 +39,15 @@ if (!codexConfig || typeof codexConfig !== 'object') {
 const firebaseConfig = codexConfig.firebaseConfig;
 const BACKEND_SERVER_URL =
     typeof codexConfig.backendUrl === 'string' ? codexConfig.backendUrl.trim() : '';
-const AI_FEATURES_AVAILABLE = BACKEND_SERVER_URL.length > 0;const AVATAR_ASSETS = Object.freeze({
+const AI_FEATURES_AVAILABLE = BACKEND_SERVER_URL.length > 0;
+const AVATAR_ASSETS = Object.freeze({
     modelSrc: 'assets/avatars/codex-vitae-avatar.gltf',
-    placeholderSrc: 'assets/avatars/codex-vitae-avatar-placeholder.svg',
+    placeholderSrc: 'assets/avatars/avatar-placeholder-casual-park.jpg',
     legacyPlaceholderSrc: 'assets/avatars/avatar-placeholder-casual-park.jpg',
     modelExtensions: Object.freeze(['.glb', '.gltf'])
 });
 const DEFAULT_AVATAR_MODEL_SRC = 'assets/avatars/codex-vitae-avatar.gltf';
-const DEFAULT_AVATAR_PLACEHOLDER_SRC = 'assets/avatars/codex-vitae-avatar-placeholder.svg';
+const DEFAULT_AVATAR_PLACEHOLDER_SRC = 'assets/avatars/avatar-placeholder-casual-park.jpg';
 const LEGACY_AVATAR_PLACEHOLDER_SRC = 'assets/avatars/avatar-placeholder-casual-park.jpg';
 const AVATAR_MODEL_EXTENSIONS = ['.glb', '.gltf'];
 


### PR DESCRIPTION
## Summary
- switch the default avatar placeholder sources to the casual park illustration asset
- update the landing markup to load the new image placeholder
- simplify placeholder styling so the photo fills the avatar stage cleanly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d467c7bdf88321a86b0e9d70a64114