### PR TITLE
Add feature-flagged modern WebGL pipeline scaffolding

### DIFF
--- a/index.html
+++ b/index.html
@@ -321,5 +321,12 @@
     <!-- Configuration values (firebase config, backend URL) -->
     <script src="config.js?v=20240610"></script>
     <script src="js/main.js?v=20240610"></script>
+    <script src="vendor/three-r160.min.js"></script>
+    <script type="module" src="js/pipeline/webgl-pipeline.js"></script>
+    <script src="js/pipeline/texture-store.js"></script>
+    <script>
+      window.CVPipeline = window.CVPipeline || {};
+      if (location.search.includes('fx=on')) window.CVPipeline.enabled = true;
+    </script>
 </body>
 </html>

--- a/js/pipeline/texture-store.js
+++ b/js/pipeline/texture-store.js
@@ -1,0 +1,43 @@
+(function(){
+  const cache = new Map();
+  let pmremGen = null, rendererRef = null, rgbeLoader = null, texLoader = null;
+
+  function key(u,o){ return u+'|'+JSON.stringify(o||{}); }
+
+  window.CVTextures = {
+    init(renderer){
+      rendererRef = renderer;
+      pmremGen = new THREE.PMREMGenerator(renderer);
+      pmremGen.compileEquirectangularShader();
+      texLoader = texLoader || new THREE.TextureLoader();
+      // RGBELoader comes from module island
+      rgbeLoader = rgbeLoader || new window.CVPipeline.RGBELoader();
+    },
+    async getTexture(url, opts={}){
+      const k = key(url, opts);
+      if (cache.has(k)) return cache.get(k);
+      const t = await new Promise((res, rej)=>{
+        texLoader.load(url, res, undefined, rej);
+      });
+      if (opts.srgb) t.colorSpace = THREE.SRGBColorSpace;
+      if (opts.flipY !== undefined) t.flipY = opts.flipY;
+      if (opts.repeat){ t.wrapS = t.wrapT = THREE.RepeatWrapping; t.repeat.set(opts.repeat[0], opts.repeat[1]); }
+      if (opts.offset){ t.offset.set(opts.offset[0], opts.offset[1]); }
+      cache.set(k, t); return t;
+    },
+    async getHDR(url){
+      const k = key(url, {hdr:true});
+      if (cache.has(k)) return cache.get(k);
+      const tex = await new Promise((res, rej)=>{ rgbeLoader.load(url, res, undefined, rej); });
+      cache.set(k, tex); return tex;
+    },
+    async getEnvironmentFromHDR(url){
+      const k = key(url, {env:true});
+      if (cache.has(k)) return cache.get(k);
+      const hdr = await this.getHDR(url);
+      const env = pmremGen.fromEquirectangular(hdr).texture;
+      hdr.dispose?.();
+      cache.set(k, env); return env;
+    }
+  };
+})();

--- a/js/pipeline/webgl-pipeline.js
+++ b/js/pipeline/webgl-pipeline.js
@@ -1,0 +1,18 @@
+import { EffectComposer } from 'https://unpkg.com/three@0.160/examples/jsm/postprocessing/EffectComposer.js';
+import { RenderPass } from 'https://unpkg.com/three@0.160/examples/jsm/postprocessing/RenderPass.js';
+import { UnrealBloomPass } from 'https://unpkg.com/three@0.160/examples/jsm/postprocessing/UnrealBloomPass.js';
+import { ShaderPass } from 'https://unpkg.com/three@0.160/examples/jsm/postprocessing/ShaderPass.js';
+import { RGBELoader } from 'https://unpkg.com/three@0.160/examples/jsm/loaders/RGBELoader.js';
+
+window.CVPipeline = Object.assign(window.CVPipeline || {}, {
+  EffectComposer, RenderPass, UnrealBloomPass, ShaderPass, RGBELoader,
+  createComposer(renderer, scene, camera, { bloom = true, grade = false } = {}) {
+    const composer = new EffectComposer(renderer);
+    composer.addPass(new RenderPass(scene, camera));
+    if (bloom) {
+      const pass = new UnrealBloomPass(undefined, 0.9, 0.4, 0.8);
+      composer.addPass(pass);
+    }
+    return composer;
+  }
+});

--- a/vendor/three-r160.min.js
+++ b/vendor/three-r160.min.js
@@ -1,0 +1,8 @@
+/*! three.js r160 loader placeholder. Replace with the official build when packaging for production. */
+(function(){
+  if (window.THREE) { return; }
+  var script = document.createElement('script');
+  script.src = 'https://unpkg.com/three@0.160.0/build/three.min.js';
+  script.crossOrigin = 'anonymous';
+  document.head.appendChild(script);
+})();


### PR DESCRIPTION
## Summary
- add a feature-flagged Three.js pipeline module that exposes common post-processing helpers
- introduce a shared texture and PMREM cache utility for the modern renderer path
- load the new assets from index.html and gate activation behind an `fx=on` query flag

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6c495dd808321b03367da23625164