### PR TITLE
Add diagnostics HUD for debug pipeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -322,6 +322,7 @@
     <script src="config.js?v=20240610"></script>
     <script src="js/main.js?v=20240610"></script>
     <script src="vendor/three-r160.min.js"></script>
+    <script src="js/pipeline/passes/grade-pass.js"></script>
     <script type="module" src="js/pipeline/webgl-pipeline.js"></script>
     <script src="js/pipeline/texture-store.js"></script>
     <script>

--- a/js/pipeline/passes/grade-pass.js
+++ b/js/pipeline/passes/grade-pass.js
@@ -1,0 +1,60 @@
+(function(){
+  const CVGradeShader = {
+    uniforms: {
+      tDiffuse: { value: null },
+      uLift:    { value: new THREE.Vector3(0.00, 0.00, 0.00) },
+      uGamma:   { value: new THREE.Vector3(1.00, 1.00, 1.00) },
+      uGain:    { value: new THREE.Vector3(1.05, 1.05, 1.08) }, // slight pop
+      uVignetteStrength: { value: 0.18 },
+      uCAStrength: { value: 0.005 }, // very subtle
+      uResolution: { value: new THREE.Vector2(1,1) }
+    },
+    vertexShader: /* glsl */`
+      varying vec2 vUv;
+      void main(){
+        vUv = uv;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position,1.0);
+      }
+    `,
+    fragmentShader: /* glsl */`
+      precision highp float;
+      varying vec2 vUv;
+      uniform sampler2D tDiffuse;
+      uniform vec3 uLift, uGamma, uGain;
+      uniform float uVignetteStrength, uCAStrength;
+      uniform vec2 uResolution;
+
+      vec3 liftGammaGain(vec3 c, vec3 lift, vec3 gamma, vec3 gain){
+        c = (c + lift);
+        c = pow(max(c, 0.0), 1.0 / max(gamma, vec3(0.001)));
+        c = c * gain;
+        return c;
+      }
+
+      vec3 vignette(vec3 c, vec2 uv, float k){
+        if (k <= 0.0) return c;
+        vec2 p = uv - 0.5;
+        float v = smoothstep(0.9, 0.2, length(p)) * k; // darker toward edges
+        return c * (1.0 - v);
+      }
+
+      vec3 chromaticAberration(vec2 uv, float s){
+        if (s <= 0.0) return texture2D(tDiffuse, uv).rgb;
+        vec2 dir = (uv - 0.5);
+        vec2 off = dir * s;
+        float r = texture2D(tDiffuse, uv + off).r;
+        float g = texture2D(tDiffuse, uv).g;
+        float b = texture2D(tDiffuse, uv - off).b;
+        return vec3(r,g,b);
+      }
+
+      void main(){
+        vec3 col = chromaticAberration(vUv, uCAStrength);
+        col = liftGammaGain(col, uLift, uGamma, uGain);
+        col = vignette(col, vUv, uVignetteStrength);
+        gl_FragColor = vec4(col, 1.0);
+      }
+    `
+  };
+  window.CVGradeShader = CVGradeShader;
+})();

--- a/js/pipeline/webgl-pipeline.js
+++ b/js/pipeline/webgl-pipeline.js
@@ -6,13 +6,41 @@ import { RGBELoader } from 'https://unpkg.com/three@0.160/examples/jsm/loaders/R
 
 window.CVPipeline = Object.assign(window.CVPipeline || {}, {
   EffectComposer, RenderPass, UnrealBloomPass, ShaderPass, RGBELoader,
-  createComposer(renderer, scene, camera, { bloom = true, grade = false } = {}) {
+  createComposer(renderer, scene, camera, { bloom = true, grade = true } = {}) {
     const composer = new EffectComposer(renderer);
-    composer.addPass(new RenderPass(scene, camera));
+    const renderPass = new RenderPass(scene, camera);
+    composer.addPass(renderPass);
+
     if (bloom) {
       const pass = new UnrealBloomPass(undefined, 0.9, 0.4, 0.8);
       composer.addPass(pass);
+      composer.__bloom = pass;
     }
+
+    if (grade && window.CVGradeShader) {
+      const gradePass = new ShaderPass(window.CVGradeShader);
+      const originalSetSize = composer.setSize.bind(composer);
+      composer.setSize = function setSize(w, h) {
+        originalSetSize(w, h);
+        if (gradePass.uniforms?.uResolution?.value?.set) {
+          gradePass.uniforms.uResolution.value.set(w, h);
+        }
+      };
+      if (gradePass.uniforms?.uResolution?.value) {
+        if (typeof renderer.getSize === 'function') {
+          renderer.getSize(gradePass.uniforms.uResolution.value);
+        } else if (renderer.domElement) {
+          gradePass.uniforms.uResolution.value.set(
+            renderer.domElement.width || renderer.domElement.clientWidth || 1,
+            renderer.domElement.height || renderer.domElement.clientHeight || 1
+          );
+        }
+      }
+      composer.addPass(gradePass);
+      composer.__grade = gradePass;
+    }
+
+    composer.__renderPass = renderPass;
     return composer;
   }
 });

--- a/js/skill-universe-renderer.js
+++ b/js/skill-universe-renderer.js
@@ -520,6 +520,11 @@
             this._environmentTarget = null;
             this._environmentMap = null;
             this._rgbeLoader = null;
+            this._debugUIPanel = null;
+            this._diagnosticsPanel = null;
+            this._diagnosticsFields = null;
+            this._diagnosticsInterval = null;
+            this._environmentName = null;
             // modern pipeline handles (created only when fx=on)
             this._glRenderer = null;
             this._composer = null;
@@ -566,7 +571,7 @@
                         this._glRenderer,
                         this.scene,
                         this.camera,
-                        { bloom: true, grade: false }
+                        { bloom: true, grade: true }
                     );
                 } catch (composerError) {
                     if (typeof console !== 'undefined' && typeof console.warn === 'function') {
@@ -584,6 +589,223 @@
 
                 if (this._glRenderer && this._composer) {
                     this.renderer = this._glRenderer;
+                    if (
+                        useModern &&
+                        typeof global.location?.search === 'string' &&
+                        global.location.search.includes('debug') &&
+                        global.document &&
+                        typeof global.document.createElement === 'function'
+                    ) {
+                        try {
+                            const doc = global.document;
+                            const ui = doc.getElementById('cv-debug') || doc.createElement('div');
+                            ui.id = 'cv-debug';
+                            ui.style.cssText = [
+                                'position:fixed',
+                                'top:8px',
+                                'right:8px',
+                                'z-index:9999',
+                                'background:rgba(12,16,28,0.88)',
+                                'color:#fff',
+                                'padding:8px 10px',
+                                'min-width:180px',
+                                'max-width:220px',
+                                'font-family:system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+                                'font-size:12px',
+                                'line-height:1.4',
+                                'border-radius:6px',
+                                'box-shadow:0 6px 18px rgba(0,0,0,0.35)',
+                                'backdrop-filter:blur(6px)'
+                            ].join(';');
+                            ui.innerHTML = '';
+
+                            const title = doc.createElement('div');
+                            title.textContent = 'FX Debug';
+                            title.style.cssText = 'font-weight:600;margin-bottom:4px;text-transform:uppercase;letter-spacing:0.06em;';
+                            ui.appendChild(title);
+
+                            const slider = (label, min, max, step, get, set, formatter = (v) => v.toFixed(2)) => {
+                                const row = doc.createElement('label');
+                                row.style.cssText = 'display:block;margin:6px 0;';
+
+                                const labelSpan = doc.createElement('span');
+                                labelSpan.textContent = label;
+                                labelSpan.style.cssText = 'display:inline-block;margin-bottom:2px;';
+                                row.appendChild(labelSpan);
+
+                                const input = doc.createElement('input');
+                                input.type = 'range';
+                                input.min = String(min);
+                                input.max = String(max);
+                                input.step = String(step);
+                                const current = get();
+                                input.value = isNaN(current) ? String(min) : String(current);
+                                input.style.width = '100%';
+
+                                const valueReadout = doc.createElement('div');
+                                valueReadout.textContent = formatter(parseFloat(input.value));
+                                valueReadout.style.cssText = 'font-size:11px;opacity:0.72;margin-top:2px;text-align:right;';
+
+                                input.addEventListener('input', () => {
+                                    const value = parseFloat(input.value);
+                                    if (!Number.isNaN(value)) {
+                                        set(value);
+                                        valueReadout.textContent = formatter(value);
+                                    }
+                                });
+
+                                row.appendChild(input);
+                                row.appendChild(valueReadout);
+                                ui.appendChild(row);
+                            };
+
+                            slider(
+                                'Exposure',
+                                0.1,
+                                2.5,
+                                0.01,
+                                () => this._glRenderer.toneMappingExposure,
+                                (value) => {
+                                    this._glRenderer.toneMappingExposure = value;
+                                }
+                            );
+
+                            const bloom = this._composer.__bloom;
+                            if (bloom) {
+                                slider('Bloom Strength', 0.0, 2.0, 0.01, () => bloom.strength, (value) => {
+                                    bloom.strength = value;
+                                });
+                                slider('Bloom Threshold', 0.0, 1.5, 0.01, () => bloom.threshold, (value) => {
+                                    bloom.threshold = value;
+                                });
+                                slider('Bloom Radius', 0.0, 1.5, 0.01, () => bloom.radius, (value) => {
+                                    bloom.radius = value;
+                                });
+                            }
+
+                            const grade = this._composer.__grade;
+                            if (grade?.uniforms) {
+                                const { uniforms } = grade;
+                                const monoVecSlider = (label, key, min, max, step) => {
+                                    if (!uniforms[key]?.value) {
+                                        return;
+                                    }
+                                    slider(
+                                        label,
+                                        min,
+                                        max,
+                                        step,
+                                        () => uniforms[key].value.x ?? 0,
+                                        (value) => {
+                                            if (typeof uniforms[key].value.set === 'function') {
+                                                uniforms[key].value.set(value, value, value);
+                                            }
+                                        }
+                                    );
+                                };
+
+                                monoVecSlider('Lift', -0.3, 0.3, 0.005);
+                                monoVecSlider('Gamma', 0.5, 2.0, 0.01);
+                                monoVecSlider('Gain', 0.5, 1.6, 0.01);
+
+                                if (uniforms.uVignetteStrength) {
+                                    slider(
+                                        'Vignette',
+                                        0.0,
+                                        0.6,
+                                        0.01,
+                                        () => uniforms.uVignetteStrength.value ?? 0,
+                                        (value) => {
+                                            uniforms.uVignetteStrength.value = value;
+                                        }
+                                    );
+                                }
+
+                                if (uniforms.uCAStrength) {
+                                    slider(
+                                        'Chromatic Aberration',
+                                        0.0,
+                                        0.02,
+                                        0.0005,
+                                        () => uniforms.uCAStrength.value ?? 0,
+                                        (value) => {
+                                            uniforms.uCAStrength.value = value;
+                                        },
+                                        (value) => value.toFixed(4)
+                                    );
+                                }
+                            }
+
+                            if (!ui.parentElement) {
+                                doc.body.appendChild(ui);
+                            }
+                            this._debugUIPanel = ui;
+
+                            const diag = doc.getElementById('cv-diag') || doc.createElement('div');
+                            diag.id = 'cv-diag';
+                            diag.style.cssText = [
+                                'position:fixed',
+                                'top:8px',
+                                'left:8px',
+                                'z-index:9998',
+                                'background:rgba(6,10,20,0.82)',
+                                'color:#d8f1ff',
+                                'padding:6px 8px',
+                                'font-family:"IBM Plex Mono", SFMono-Regular, Menlo, Monaco, monospace',
+                                'font-size:11px',
+                                'line-height:1.45',
+                                'border-radius:4px',
+                                'pointer-events:none',
+                                'user-select:none',
+                                'box-shadow:0 4px 12px rgba(0,0,0,0.35)',
+                                'max-width:220px'
+                            ].join(';');
+                            diag.innerHTML = '';
+
+                            const createRow = (label, key) => {
+                                const row = doc.createElement('div');
+                                row.style.cssText = 'display:flex;gap:6px;justify-content:space-between;';
+                                const labelSpan = doc.createElement('span');
+                                labelSpan.textContent = `${label}:`;
+                                labelSpan.style.cssText = 'opacity:0.7;';
+                                const valueSpan = doc.createElement('span');
+                                valueSpan.dataset.field = key;
+                                valueSpan.textContent = '…';
+                                row.appendChild(labelSpan);
+                                row.appendChild(valueSpan);
+                                diag.appendChild(row);
+                                return valueSpan;
+                            };
+
+                            this._diagnosticsFields = {
+                                pipeline: createRow('Pipeline', 'pipeline'),
+                                passes: createRow('Composer', 'passes'),
+                                tone: createRow('Tone mapping', 'tone'),
+                                ibl: createRow('IBL', 'ibl'),
+                                nebula: createRow('Nebula planes', 'nebula'),
+                                sprites: createRow('Sprite stars', 'sprites'),
+                                pbr: createRow('PBR stars', 'pbr')
+                            };
+
+                            if (!diag.parentElement) {
+                                doc.body.appendChild(diag);
+                            }
+                            this._diagnosticsPanel = diag;
+                            this._updateDiagnostics();
+                            if (this._diagnosticsInterval && typeof global.clearInterval === 'function') {
+                                global.clearInterval(this._diagnosticsInterval);
+                            }
+                            if (typeof global.setInterval === 'function') {
+                                this._diagnosticsInterval = global.setInterval(() => {
+                                    this._updateDiagnostics();
+                                }, 1000);
+                            }
+                        } catch (debugError) {
+                            if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+                                console.warn('SkillUniverseRenderer: debug panel failed to initialize', debugError);
+                            }
+                        }
+                    }
                 } else if (this._glRenderer && !this._composer) {
                     if (typeof this._glRenderer.dispose === 'function') {
                         this._glRenderer.dispose();
@@ -1045,6 +1267,7 @@
                         if (this._environmentMap && typeof this._environmentMap.mapping !== 'undefined' && typeof THREE.EquirectangularReflectionMapping !== 'undefined') {
                             this._environmentMap.mapping = THREE.EquirectangularReflectionMapping;
                         }
+                        this._environmentName = hdrUrl;
                         if (this.scene) {
                             this.scene.environment = this._environmentMap;
                             this.scene.background = this._environmentMap;
@@ -1267,8 +1490,104 @@
             }
         }
 
+        _updateDiagnostics() {
+            if (!this._diagnosticsPanel || !this._diagnosticsFields) {
+                return;
+            }
+
+            const fields = this._diagnosticsFields;
+            const pipelineActive = (this._glRenderer && this._composer) ? 'Modern WebGL' : 'Legacy';
+            fields.pipeline.textContent = pipelineActive;
+
+            if (this._composer) {
+                const bloomPass = this._composer.__bloom;
+                const gradePass = this._composer.__grade;
+                const bloomState = bloomPass && bloomPass.enabled === false ? 'off' : (bloomPass ? 'on' : 'missing');
+                const gradeState = gradePass && gradePass.enabled === false ? 'off' : (gradePass ? 'on' : 'missing');
+                fields.passes.textContent = `Render • Bloom: ${bloomState} • Grade: ${gradeState}`;
+            } else {
+                fields.passes.textContent = 'n/a';
+            }
+
+            const renderer = this._glRenderer || this.renderer || null;
+            if (renderer && typeof renderer.toneMapping !== 'undefined') {
+                let toneLabel = 'Custom';
+                if (renderer.toneMapping === THREE.ACESFilmicToneMapping) {
+                    toneLabel = 'ACES';
+                }
+                const exposure = typeof renderer.toneMappingExposure === 'number'
+                    ? renderer.toneMappingExposure.toFixed(2)
+                    : null;
+                fields.tone.textContent = exposure ? `${toneLabel} (exp ${exposure})` : toneLabel;
+            } else {
+                fields.tone.textContent = 'n/a';
+            }
+
+            const environmentLabel = (() => {
+                if (typeof this._environmentName === 'string' && this._environmentName.length) {
+                    const parts = this._environmentName.split(/[/\\]/);
+                    const base = parts[parts.length - 1] || this._environmentName;
+                    return base;
+                }
+                if (this.scene?.environment) {
+                    return this.scene.environment.name || 'active';
+                }
+                return 'none';
+            })();
+            fields.ibl.textContent = environmentLabel;
+
+            const nebulaCount = Array.isArray(this._nebulaPlanes) ? this._nebulaPlanes.length : 0;
+            const dynamicLayerCount = (this._nebulaLayer && typeof this._nebulaLayer.getPlaneCount === 'function')
+                ? Number(this._nebulaLayer.getPlaneCount()) || 0
+                : 0;
+            fields.nebula.textContent = dynamicLayerCount
+                ? `${nebulaCount} + ${dynamicLayerCount}`
+                : String(nebulaCount);
+
+            let spriteCount = 0;
+            const spritePoints = this._spriteStars;
+            if (spritePoints?.geometry?.getAttribute) {
+                const attr = spritePoints.geometry.getAttribute('position');
+                if (attr && typeof attr.count === 'number') {
+                    spriteCount = attr.count;
+                }
+            }
+            fields.sprites.textContent = String(spriteCount);
+
+            let totalStars = 0;
+            let pbrStars = 0;
+            if (this.starMeshMap && typeof this.starMeshMap.forEach === 'function') {
+                this.starMeshMap.forEach((mesh) => {
+                    if (!mesh) {
+                        return;
+                    }
+                    totalStars += 1;
+                    if (mesh.userData && mesh.userData.usesPBR) {
+                        pbrStars += 1;
+                    }
+                });
+            }
+            const fallbackStars = totalStars - pbrStars;
+            fields.pbr.textContent = totalStars
+                ? `${pbrStars}/${totalStars} using PBR • ${fallbackStars} fallback`
+                : '0 using PBR • 0 fallback';
+        }
+
         destroy() {
             cancelAnimationFrame(this._animationFrame);
+            if (this._diagnosticsInterval && typeof global.clearInterval === 'function') {
+                global.clearInterval(this._diagnosticsInterval);
+            }
+            this._diagnosticsInterval = null;
+            if (this._diagnosticsPanel && this._diagnosticsPanel.parentElement) {
+                this._diagnosticsPanel.parentElement.removeChild(this._diagnosticsPanel);
+            }
+            this._diagnosticsPanel = null;
+            this._diagnosticsFields = null;
+            if (this._debugUIPanel && this._debugUIPanel.parentElement) {
+                this._debugUIPanel.parentElement.removeChild(this._debugUIPanel);
+            }
+            this._debugUIPanel = null;
             if (this.starMeshMap && this.starMeshMap.size) {
                 this.starMeshMap.forEach((mesh) => {
                     this._applyTextureLayers(mesh, null);
@@ -1353,6 +1672,7 @@
                 this._environmentMap.dispose();
             }
             this._environmentMap = null;
+            this._environmentName = null;
             if (this.scene) {
                 this.scene.environment = null;
                 this.scene.background = null;
@@ -2676,6 +2996,8 @@
                 material.emissiveIntensity = emissiveIntensity;
                 material.roughness = roughness;
                 material.metalness = metalness;
+                mesh.userData = Object.assign({}, mesh.userData, { usesPBR: false });
+                this._updateDiagnostics();
             };
 
             const texturesApi = global.CVTextures || (typeof window !== 'undefined' ? window.CVTextures : null);
@@ -2915,6 +3237,8 @@
                 }
                 mesh.material = m;
                 mesh.material.needsUpdate = true;
+                mesh.userData = Object.assign({}, mesh.userData, { usesPBR: true });
+                this._updateDiagnostics();
             } catch (err) {
                 applyLegacyMaterial(descriptor);
             }
@@ -3482,6 +3806,7 @@
                 const hdrUrl = neb.maps.environment;
                 const envTex = await global.CVTextures.getEnvironmentFromHDR(hdrUrl);
                 if (envTex) {
+                    this._environmentName = hdrUrl;
                     this.scene.environment = envTex;
                 }
             } catch (err) {
@@ -3512,6 +3837,7 @@
                 const hdrUrl = neb.maps.environment;
                 const envTex = await global.CVTextures.getEnvironmentFromHDR(hdrUrl);
                 if (envTex) {
+                    this._environmentName = hdrUrl;
                     this.scene.environment = envTex;
                 }
             } catch (err) {


### PR DESCRIPTION
## Summary
- add a custom lift/gamma/gain grading shader with vignette and subtle chromatic aberration
- update the pipeline to wire the new grading pass after bloom and expose pass handles for debugging
- inject an optional `?debug` slider panel to tweak exposure, bloom, and grading parameters and ensure the shader script loads
- add a diagnostics HUD for `?fx=on&debug` that reports pipeline, pass, environment, and star material stats

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6d7d7d24883218de7afacef10ff6e