### PR TITLE
Fix WebGL pipeline imports to resolve three module

### DIFF
--- a/js/pipeline/webgl-pipeline.js
+++ b/js/pipeline/webgl-pipeline.js
@@ -1,8 +1,8 @@
-import { EffectComposer } from 'https://unpkg.com/three@0.160/examples/jsm/postprocessing/EffectComposer.js';
-import { RenderPass } from 'https://unpkg.com/three@0.160/examples/jsm/postprocessing/RenderPass.js';
-import { UnrealBloomPass } from 'https://unpkg.com/three@0.160/examples/jsm/postprocessing/UnrealBloomPass.js';
-import { ShaderPass } from 'https://unpkg.com/three@0.160/examples/jsm/postprocessing/ShaderPass.js';
-import { RGBELoader } from 'https://unpkg.com/three@0.160/examples/jsm/loaders/RGBELoader.js';
+import { EffectComposer } from 'https://unpkg.com/three@0.160/examples/jsm/postprocessing/EffectComposer.js?module';
+import { RenderPass } from 'https://unpkg.com/three@0.160/examples/jsm/postprocessing/RenderPass.js?module';
+import { UnrealBloomPass } from 'https://unpkg.com/three@0.160/examples/jsm/postprocessing/UnrealBloomPass.js?module';
+import { ShaderPass } from 'https://unpkg.com/three@0.160/examples/jsm/postprocessing/ShaderPass.js?module';
+import { RGBELoader } from 'https://unpkg.com/three@0.160/examples/jsm/loaders/RGBELoader.js?module';
 
 window.CVPipeline = Object.assign(window.CVPipeline || {}, {
   EffectComposer, RenderPass, UnrealBloomPass, ShaderPass, RGBELoader,


### PR DESCRIPTION
## Summary
- ensure the pipeline module loads three.js example dependencies via unpkg `?module` URLs so the browser resolves the bare `"three"` specifier

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6e707aae88321859d4e7d7f25658b