### PR TITLE
Add import map to resolve Three.js module dependencies

### DIFF
--- a/index.html
+++ b/index.html
@@ -323,6 +323,13 @@
     <script src="js/main.js?v=20240610"></script>
     <script src="vendor/three-r160.min.js"></script>
     <script src="js/pipeline/passes/grade-pass.js"></script>
+    <script type="importmap">
+        {
+            "imports": {
+                "three": "https://unpkg.com/three@0.160/build/three.module.js"
+            }
+        }
+    </script>
     <script type="module" src="js/pipeline/webgl-pipeline.js"></script>
     <script src="js/pipeline/texture-store.js"></script>
     <script>


### PR DESCRIPTION
## Summary
- add an import map that maps the Three.js module specifier used by the post-processing pipeline to the CDN build so module imports resolve again

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6e2f227208321869b98a7982d3dd6