### PR TITLE
Add camera orbit controls and vertical depth to Skill Universe

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -613,6 +613,12 @@ model-viewer.avatar-viewer {
     gap: 8px;
 }
 
+.skill-tree-orbit-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
 .skill-tree-pan-button {
     width: 36px;
     height: 36px;
@@ -627,6 +633,39 @@ model-viewer.avatar-viewer {
 }
 
 .skill-tree-pan-button:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.skill-orbit-button {
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.05em;
+    line-height: 1;
+    background: rgba(20, 38, 58, 0.72);
+    color: #f6f9fb;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    box-shadow: 0 6px 14px rgba(32, 60, 80, 0.28);
+    transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.skill-orbit-button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 20px rgba(45, 85, 110, 0.35);
+}
+
+.skill-orbit-button:active {
+    transform: translateY(0);
+    box-shadow: 0 4px 10px rgba(20, 38, 58, 0.3);
+}
+
+.skill-orbit-button:disabled {
     opacity: 0.45;
     cursor: not-allowed;
     box-shadow: none;

--- a/index.html
+++ b/index.html
@@ -276,6 +276,18 @@
                         <button id="skill-pan-left" class="skill-tree-pan-button" type="button" aria-label="Nudge constellations left">&#8592;</button>
                         <button id="skill-pan-right" class="skill-tree-pan-button" type="button" aria-label="Nudge constellations right">&#8594;</button>
                     </div>
+                    <div
+                        id="skill-tree-orbit-controls"
+                        class="skill-tree-orbit-controls hidden"
+                        role="group"
+                        aria-label="Camera orbit controls"
+                    >
+                        <button id="skill-orbit-up" class="skill-orbit-button" type="button" aria-label="Tilt camera up">&#8593;</button>
+                        <button id="skill-orbit-left" class="skill-orbit-button" type="button" aria-label="Orbit left">&#10226;</button>
+                        <button id="skill-orbit-reset" class="skill-orbit-button" type="button" aria-label="Reset camera view">&#10686;</button>
+                        <button id="skill-orbit-right" class="skill-orbit-button" type="button" aria-label="Orbit right">&#10227;</button>
+                        <button id="skill-orbit-down" class="skill-orbit-button" type="button" aria-label="Tilt camera down">&#8595;</button>
+                    </div>
                     <button id="close-skills-btn" type="button">Close</button>
                 </div>
             </div>

--- a/js/main.js
+++ b/js/main.js
@@ -95,6 +95,12 @@ const skillSearchInput = document.getElementById('skill-search-input');
 const skillTreePanControls = document.getElementById('skill-tree-pan-controls');
 const skillPanLeftBtn = document.getElementById('skill-pan-left');
 const skillPanRightBtn = document.getElementById('skill-pan-right');
+const skillOrbitControls = document.getElementById('skill-tree-orbit-controls');
+const skillOrbitUpBtn = document.getElementById('skill-orbit-up');
+const skillOrbitDownBtn = document.getElementById('skill-orbit-down');
+const skillOrbitLeftBtn = document.getElementById('skill-orbit-left');
+const skillOrbitRightBtn = document.getElementById('skill-orbit-right');
+const skillOrbitResetBtn = document.getElementById('skill-orbit-reset');
 const authEmailInput = document.getElementById('email-input');
 const authPasswordInput = document.getElementById('password-input');
 const loginButton = document.getElementById('login-btn');
@@ -114,6 +120,8 @@ const LEGACY_ROLLOVER_THRESHOLD = 1000;
 const MAX_MAJOR_STAT_VALUE = 100;
 const STATS_PER_PERK_POINT = 10;
 const QUARTERLY_MILESTONE_GOAL = 60;
+const CAMERA_ORBIT_AZIMUTH_STEP = Math.PI / 24;
+const CAMERA_ORBIT_POLAR_STEP = Math.PI / 40;
 
 function getQuarterIdentifier(date) {
     const reference = date instanceof Date ? date : new Date(date);
@@ -2402,10 +2410,35 @@ function renderSkillTreeBreadcrumbs(breadcrumbs) {
     });
 }
 
+function updateOrbitControlsState() {
+    if (!skillOrbitControls) {
+        return;
+    }
+
+    const rendererReady = !!(skillRenderer && typeof skillRenderer.nudgeOrbit === 'function');
+    skillOrbitControls.classList.toggle('hidden', !rendererReady);
+    skillOrbitControls.setAttribute('aria-hidden', rendererReady ? 'false' : 'true');
+
+    const orbitButtons = [
+        skillOrbitUpBtn,
+        skillOrbitDownBtn,
+        skillOrbitLeftBtn,
+        skillOrbitRightBtn,
+        skillOrbitResetBtn
+    ];
+
+    orbitButtons.forEach((button) => {
+        if (button) {
+            button.disabled = !rendererReady;
+        }
+    });
+}
+
 function updateSkillTreeUI(title, breadcrumbs, showBack) {
     skillTreeTitle.textContent = title;
     renderSkillTreeBreadcrumbs(breadcrumbs);
     skillBackBtn.classList.toggle('hidden', !showBack);
+    updateOrbitControlsState();
 }
 
 function deriveSkillPathType(path) {
@@ -2621,6 +2654,8 @@ function updateSkillTreeUI(title, breadcrumbs, showBack) {
             skillPanRightBtn.disabled = !showPanControls;
         }
     }
+
+    updateOrbitControlsState();
 }
 
 function showToast(message) {
@@ -3149,6 +3184,46 @@ function setupEventListeners() {
         skillPanRightBtn.addEventListener('click', () => nudgeConstellations(CONSTELLATION_PAN_NUDGE));
     }
 
+    if (skillOrbitUpBtn) {
+        skillOrbitUpBtn.addEventListener('click', () => {
+            if (skillRenderer && typeof skillRenderer.nudgeOrbit === 'function') {
+                skillRenderer.nudgeOrbit(0, -CAMERA_ORBIT_POLAR_STEP);
+            }
+        });
+    }
+
+    if (skillOrbitDownBtn) {
+        skillOrbitDownBtn.addEventListener('click', () => {
+            if (skillRenderer && typeof skillRenderer.nudgeOrbit === 'function') {
+                skillRenderer.nudgeOrbit(0, CAMERA_ORBIT_POLAR_STEP);
+            }
+        });
+    }
+
+    if (skillOrbitLeftBtn) {
+        skillOrbitLeftBtn.addEventListener('click', () => {
+            if (skillRenderer && typeof skillRenderer.nudgeOrbit === 'function') {
+                skillRenderer.nudgeOrbit(-CAMERA_ORBIT_AZIMUTH_STEP, 0);
+            }
+        });
+    }
+
+    if (skillOrbitRightBtn) {
+        skillOrbitRightBtn.addEventListener('click', () => {
+            if (skillRenderer && typeof skillRenderer.nudgeOrbit === 'function') {
+                skillRenderer.nudgeOrbit(CAMERA_ORBIT_AZIMUTH_STEP, 0);
+            }
+        });
+    }
+
+    if (skillOrbitResetBtn) {
+        skillOrbitResetBtn.addEventListener('click', () => {
+            if (skillRenderer && typeof skillRenderer.resetOrbit === 'function') {
+                skillRenderer.resetOrbit();
+            }
+        });
+    }
+
     if (skillBackBtn) {
         skillBackBtn.addEventListener('click', () => {
             starDetailController.hide();
@@ -3308,6 +3383,7 @@ if (typeof window.SkillUniverseRenderer === 'function') {
         }
     });
 
+    updateOrbitControlsState();
     rebuildSkillUniverseIfReady();
 } else {
     console.warn(
@@ -3317,6 +3393,7 @@ if (typeof window.SkillUniverseRenderer === 'function') {
         skillTreeContainer.innerHTML =
             '<p class="skill-tree-unavailable">3D skill tree unavailable (offline or missing Three.js).</p>';
     }
+    updateOrbitControlsState();
 }
 
 })();

--- a/js/skill-universe-renderer.js
+++ b/js/skill-universe-renderer.js
@@ -357,12 +357,22 @@
             return null;
         };
 
+    function hashToUnit(value) {
+        const x = Math.sin(value * 127.1) * 43758.5453123;
+        return x - Math.floor(x);
+    }
+
     function createRadialPosition(index, total, radius, verticalAmplitude = 0) {
         const safeTotal = Math.max(total || 0, 1);
         const angle = (index % safeTotal) / safeTotal * Math.PI * 2;
         const x = Math.cos(angle) * radius;
         const z = Math.sin(angle) * radius;
-        const y = verticalAmplitude ? Math.sin(angle * 2) * verticalAmplitude : 0;
+        let y = 0;
+        if (verticalAmplitude) {
+            const wave = Math.sin(angle * 1.7) * verticalAmplitude * 0.6;
+            const scatter = (hashToUnit(index + safeTotal * 0.618) - 0.5) * 2 * verticalAmplitude * 0.4;
+            y = wave + scatter;
+        }
         return { x, y, z };
     }
 
@@ -2173,7 +2183,7 @@
                     index,
                     galaxyNames.length,
                     GALAXY_RADIUS,
-                    0
+                    GALAXY_RADIUS * 0.22
                 );
                 const galaxyPosition = toVector3(galaxyData.position, fallbackGalaxyPosition);
                 const galaxyColor = resolveEntityColor(galaxyData, 0x6c5ce7);
@@ -2302,7 +2312,7 @@
                         cIndex,
                         constellationNames.length,
                         CONSTELLATION_RADIUS,
-                        14
+                        CONSTELLATION_RADIUS * 0.18
                     );
                     const constellationPosition = toVector3(constellationData.position, fallbackConstellationPosition);
                     const constellationColor = resolveEntityColor(constellationData, 0x45aaf2);
@@ -2378,7 +2388,7 @@
                             sIndex,
                             validSystemGroups.length,
                             STAR_SYSTEM_RADIUS,
-                            12
+                            STAR_SYSTEM_RADIUS * 0.32
                         );
                         const systemPosition = toVector3(systemData?.position, fallbackSystemPosition);
                         const systemColor = resolveEntityColor(systemData, constellationColor);
@@ -2437,7 +2447,7 @@
                                 starIndex,
                                 totalStars,
                                 STAR_ORBIT_RADIUS,
-                                6
+                                STAR_ORBIT_RADIUS * 0.42
                             );
                             const starPosition = toVector3(starData?.position, fallbackStarPosition);
 
@@ -3355,6 +3365,84 @@
             }
         }
 
+        nudgeOrbit(deltaAzimuth = 0, deltaPolar = 0) {
+            if (!this.controls || !this.camera) {
+                return;
+            }
+
+            this._cancelTween();
+
+            const target = this.controls.target.clone();
+            const offset = this.camera.position.clone().sub(target);
+            if (!offset.lengthSq()) {
+                return;
+            }
+
+            const spherical = new THREE.Spherical();
+            spherical.setFromVector3(offset);
+
+            const epsilon = 0.001;
+            const minPolar = typeof this.controls.minPolarAngle === 'number'
+                ? this.controls.minPolarAngle + epsilon
+                : epsilon;
+            const maxPolar = typeof this.controls.maxPolarAngle === 'number'
+                ? this.controls.maxPolarAngle - epsilon
+                : Math.PI - epsilon;
+
+            spherical.theta += Number.isFinite(deltaAzimuth) ? deltaAzimuth : 0;
+            spherical.phi = clamp(
+                spherical.phi + (Number.isFinite(deltaPolar) ? deltaPolar : 0),
+                Math.max(epsilon, minPolar),
+                Math.min(Math.PI - epsilon, maxPolar)
+            );
+
+            offset.setFromSpherical(spherical);
+            this.camera.position.copy(target.clone().add(offset));
+
+            if (typeof this.controls.update === 'function') {
+                this.controls.update();
+            }
+
+            this.render();
+        }
+
+        resetOrbit() {
+            if (!this.controls || !this.camera) {
+                return;
+            }
+
+            this._cancelTween();
+
+            const target = this.controls.target.clone();
+            const currentOffset = this.camera.position.clone().sub(target);
+            const currentRadius = currentOffset.length();
+            const level = CAMERA_LEVELS[this.currentView] || CAMERA_LEVELS.galaxies;
+            const defaultVector = new THREE.Vector3(0, level.height, level.distance);
+            if (!defaultVector.lengthSq()) {
+                defaultVector.set(0, level.height || 1, level.distance || 1);
+            }
+
+            const minRadius = Math.max(1, this.controls.minDistance || 1);
+            const maxRadius = this.controls.maxDistance && Number.isFinite(this.controls.maxDistance)
+                ? this.controls.maxDistance
+                : currentRadius || defaultVector.length();
+            const baselineRadius = defaultVector.length() || minRadius;
+            const targetRadius = clamp(
+                Number.isFinite(currentRadius) && currentRadius > 0 ? currentRadius : baselineRadius,
+                minRadius,
+                Math.max(minRadius, maxRadius)
+            );
+
+            const direction = defaultVector.clone().normalize().multiplyScalar(targetRadius);
+            this.camera.position.copy(target.clone().add(direction));
+
+            if (typeof this.controls.update === 'function') {
+                this.controls.update();
+            }
+
+            this.render();
+        }
+
         _getWorldPosition(object3D) {
             return object3D.getWorldPosition(new THREE.Vector3());
         }
@@ -3403,6 +3491,7 @@
             domElement.addEventListener('pointerup', (event) => this._onPointerUp(event));
             domElement.addEventListener('pointercancel', (event) => this._onPointerCancel(event));
             domElement.addEventListener('click', (event) => this._onClick(event));
+            domElement.addEventListener('keydown', (event) => this._onKeyDown(event));
         }
 
         _onPointerDown(event) {
@@ -3475,6 +3564,50 @@
             const intersects = this.raycaster.intersectObjects(this.pickableObjects, false);
             const first = intersects.length ? this._findSelectable(intersects[0].object) : null;
             this._updateHover(first);
+        }
+
+        _onKeyDown(event) {
+            if (!event) {
+                return;
+            }
+
+            const targetElement = this.renderer?.domElement || null;
+            if (!targetElement || event.target !== targetElement) {
+                return;
+            }
+
+            const azimuthStep = Math.PI / 24; // ~7.5° per tap
+            const polarStep = Math.PI / 40; // ~4.5° per tap
+            let handled = false;
+
+            switch (event.key) {
+                case 'ArrowLeft':
+                    this.nudgeOrbit(-azimuthStep, 0);
+                    handled = true;
+                    break;
+                case 'ArrowRight':
+                    this.nudgeOrbit(azimuthStep, 0);
+                    handled = true;
+                    break;
+                case 'ArrowUp':
+                    this.nudgeOrbit(0, -polarStep);
+                    handled = true;
+                    break;
+                case 'ArrowDown':
+                    this.nudgeOrbit(0, polarStep);
+                    handled = true;
+                    break;
+                case 'Home':
+                    this.resetOrbit();
+                    handled = true;
+                    break;
+                default:
+                    break;
+            }
+
+            if (handled) {
+                event.preventDefault();
+            }
         }
 
         _findSelectable(object) {
@@ -3834,13 +3967,11 @@
         }
     }
 
-    SkillUniverseRenderer.VERSION = '2024.06.10';
+    SkillUniverseRenderer.VERSION = '2024.06.24';
 
     if (typeof console !== 'undefined' && console.info) {
         const lerpExists = !!(THREE && THREE.Color && THREE.Color.prototype && typeof THREE.Color.prototype.lerp === 'function');
         console.info('SkillUniverseRenderer', SkillUniverseRenderer.VERSION, 'Color.lerp available:', lerpExists);
     }
-
-    SkillUniverseRenderer.VERSION = '2024.06.02';
     global.SkillUniverseRenderer = SkillUniverseRenderer;
 })(typeof window !== 'undefined' ? window : this);


### PR DESCRIPTION
## Summary
- add on-screen and keyboard camera orbit controls so Skill Universe viewers can rotate and reset their view
- expose renderer helpers for orbit adjustments and add vertical staggering to galaxies, constellations, and stars for better depth cues
- surface the new controls in the modal UI with styling that matches existing skill tree controls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6fdbf23f08321a053b13a485ed0b6