### PR TITLE
Revise Skill Universe interaction controls

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -611,12 +611,6 @@ model-viewer.avatar-viewer {
     gap: 8px;
 }
 
-.skill-tree-orbit-controls {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-}
-
 .skill-tree-pan-button {
     width: 36px;
     height: 36px;
@@ -636,38 +630,6 @@ model-viewer.avatar-viewer {
     box-shadow: none;
 }
 
-.skill-orbit-button {
-    width: 36px;
-    height: 36px;
-    padding: 0;
-    border-radius: 50%;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1.05em;
-    line-height: 1;
-    background: rgba(20, 38, 58, 0.72);
-    color: #f6f9fb;
-    border: 1px solid rgba(255, 255, 255, 0.14);
-    box-shadow: 0 6px 14px rgba(32, 60, 80, 0.28);
-    transition: transform 0.18s ease, box-shadow 0.18s ease;
-}
-
-.skill-orbit-button:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 10px 20px rgba(45, 85, 110, 0.35);
-}
-
-.skill-orbit-button:active {
-    transform: translateY(0);
-    box-shadow: 0 4px 10px rgba(20, 38, 58, 0.3);
-}
-
-.skill-orbit-button:disabled {
-    opacity: 0.45;
-    cursor: not-allowed;
-    box-shadow: none;
-}
 
 #skill-tree-canvas-container {
     position: relative;

--- a/index.html
+++ b/index.html
@@ -276,18 +276,6 @@
                         <button id="skill-pan-left" class="skill-tree-pan-button" type="button" aria-label="Nudge constellations left">&#8592;</button>
                         <button id="skill-pan-right" class="skill-tree-pan-button" type="button" aria-label="Nudge constellations right">&#8594;</button>
                     </div>
-                    <div
-                        id="skill-tree-orbit-controls"
-                        class="skill-tree-orbit-controls hidden"
-                        role="group"
-                        aria-label="Camera orbit controls"
-                    >
-                        <button id="skill-orbit-up" class="skill-orbit-button" type="button" aria-label="Tilt camera up">&#8593;</button>
-                        <button id="skill-orbit-left" class="skill-orbit-button" type="button" aria-label="Orbit left">&#10226;</button>
-                        <button id="skill-orbit-reset" class="skill-orbit-button" type="button" aria-label="Reset camera view">&#10686;</button>
-                        <button id="skill-orbit-right" class="skill-orbit-button" type="button" aria-label="Orbit right">&#10227;</button>
-                        <button id="skill-orbit-down" class="skill-orbit-button" type="button" aria-label="Tilt camera down">&#8595;</button>
-                    </div>
                     <button id="close-skills-btn" type="button">Close</button>
                 </div>
             </div>

--- a/js/main.js
+++ b/js/main.js
@@ -95,12 +95,6 @@ const skillSearchInput = document.getElementById('skill-search-input');
 const skillTreePanControls = document.getElementById('skill-tree-pan-controls');
 const skillPanLeftBtn = document.getElementById('skill-pan-left');
 const skillPanRightBtn = document.getElementById('skill-pan-right');
-const skillOrbitControls = document.getElementById('skill-tree-orbit-controls');
-const skillOrbitUpBtn = document.getElementById('skill-orbit-up');
-const skillOrbitDownBtn = document.getElementById('skill-orbit-down');
-const skillOrbitLeftBtn = document.getElementById('skill-orbit-left');
-const skillOrbitRightBtn = document.getElementById('skill-orbit-right');
-const skillOrbitResetBtn = document.getElementById('skill-orbit-reset');
 const authEmailInput = document.getElementById('email-input');
 const authPasswordInput = document.getElementById('password-input');
 const loginButton = document.getElementById('login-btn');
@@ -2409,35 +2403,10 @@ function renderSkillTreeBreadcrumbs(breadcrumbs) {
     });
 }
 
-function updateOrbitControlsState() {
-    if (!skillOrbitControls) {
-        return;
-    }
-
-    const rendererReady = !!(skillRenderer && typeof skillRenderer.nudgeOrbit === 'function');
-    skillOrbitControls.classList.toggle('hidden', !rendererReady);
-    skillOrbitControls.setAttribute('aria-hidden', rendererReady ? 'false' : 'true');
-
-    const orbitButtons = [
-        skillOrbitUpBtn,
-        skillOrbitDownBtn,
-        skillOrbitLeftBtn,
-        skillOrbitRightBtn,
-        skillOrbitResetBtn
-    ];
-
-    orbitButtons.forEach((button) => {
-        if (button) {
-            button.disabled = !rendererReady;
-        }
-    });
-}
-
 function updateSkillTreeUI(title, breadcrumbs, showBack) {
     skillTreeTitle.textContent = title;
     renderSkillTreeBreadcrumbs(breadcrumbs);
     skillBackBtn.classList.toggle('hidden', !showBack);
-    updateOrbitControlsState();
 }
 
 function deriveSkillPathType(path) {
@@ -2640,12 +2609,6 @@ function updateSkillTreeUI(title, breadcrumbs, showBack) {
     skillTreeTitle.textContent = title;
     renderSkillTreeBreadcrumbs(breadcrumbs);
     skillBackBtn.classList.toggle('hidden', !showBack);
-
-    if (typeof updateOrbitControlsState === 'function') {
-        updateOrbitControlsState();
-    }
-
-    updateOrbitControlsState();
 }
 
 function showToast(message) {
@@ -3174,46 +3137,6 @@ function setupEventListeners() {
         skillPanRightBtn.addEventListener('click', () => nudgeConstellations(CONSTELLATION_PAN_NUDGE));
     }
 
-    if (skillOrbitUpBtn) {
-        skillOrbitUpBtn.addEventListener('click', () => {
-            if (skillRenderer && typeof skillRenderer.nudgeOrbit === 'function') {
-                skillRenderer.nudgeOrbit(0, -CAMERA_ORBIT_POLAR_STEP);
-            }
-        });
-    }
-
-    if (skillOrbitDownBtn) {
-        skillOrbitDownBtn.addEventListener('click', () => {
-            if (skillRenderer && typeof skillRenderer.nudgeOrbit === 'function') {
-                skillRenderer.nudgeOrbit(0, CAMERA_ORBIT_POLAR_STEP);
-            }
-        });
-    }
-
-    if (skillOrbitLeftBtn) {
-        skillOrbitLeftBtn.addEventListener('click', () => {
-            if (skillRenderer && typeof skillRenderer.nudgeOrbit === 'function') {
-                skillRenderer.nudgeOrbit(-CAMERA_ORBIT_AZIMUTH_STEP, 0);
-            }
-        });
-    }
-
-    if (skillOrbitRightBtn) {
-        skillOrbitRightBtn.addEventListener('click', () => {
-            if (skillRenderer && typeof skillRenderer.nudgeOrbit === 'function') {
-                skillRenderer.nudgeOrbit(CAMERA_ORBIT_AZIMUTH_STEP, 0);
-            }
-        });
-    }
-
-    if (skillOrbitResetBtn) {
-        skillOrbitResetBtn.addEventListener('click', () => {
-            if (skillRenderer && typeof skillRenderer.resetOrbit === 'function') {
-                skillRenderer.resetOrbit();
-            }
-        });
-    }
-
     if (skillBackBtn) {
         skillBackBtn.addEventListener('click', () => {
             starDetailController.hide();
@@ -3373,7 +3296,6 @@ if (typeof window.SkillUniverseRenderer === 'function') {
         }
     });
 
-    updateOrbitControlsState();
     rebuildSkillUniverseIfReady();
 } else {
     console.warn(
@@ -3383,7 +3305,6 @@ if (typeof window.SkillUniverseRenderer === 'function') {
         skillTreeContainer.innerHTML =
             '<p class="skill-tree-unavailable">3D skill tree unavailable (offline or missing Three.js).</p>';
     }
-    updateOrbitControlsState();
 }
 
 })();

--- a/js/skill-universe-renderer.js
+++ b/js/skill-universe-renderer.js
@@ -906,21 +906,21 @@
 
             this.controls = new THREE.OrbitControls(this.camera, this.renderer.domElement);
             this.controls.enableDamping = true;
-            this.controls.dampingFactor = 0.12;
+            this.controls.dampingFactor = 0.1;
             this.controls.screenSpacePanning = true;
             this.controls.minDistance = 120;
             this.controls.maxDistance = 5600;
             this.controls.enablePan = true;
             this.controls.enableZoom = true;
             this.controls.enableRotate = true;
-            this.controls.rotateSpeed = 0.35;
-            this.controls.zoomSpeed = 0.65;
-            this.controls.panSpeed = 0.8;
+            this.controls.rotateSpeed = 0.42;
+            this.controls.zoomSpeed = 0.5;
+            this.controls.panSpeed = 0.6;
             if (THREE?.MOUSE) {
                 this.controls.mouseButtons = {
-                    LEFT: THREE.MOUSE.PAN,
+                    LEFT: THREE.MOUSE.ROTATE,
                     MIDDLE: THREE.MOUSE.DOLLY,
-                    RIGHT: THREE.MOUSE.ROTATE
+                    RIGHT: THREE.MOUSE.PAN
                 };
             }
             if (THREE?.TOUCH) {


### PR DESCRIPTION
## Summary
- remove the legacy orbit control toolbar from the Skill Universe modal and associated styles/scripts
- retune the Three.js OrbitControls mapping for smoother camera motion with left-drag orbiting and right-drag panning

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7daba26d883219ca38a20d65408f9