### PR TITLE
Remove hardcoded API keys and document configuration requirements

### DIFF
--- a/cloud-function/README.md
+++ b/cloud-function/README.md
@@ -4,6 +4,9 @@ This directory contains the Express application that fronts calls to Vertex AI f
 
 ## Required configuration
 
+- `GENAI_API_KEY`: Google Generative AI (Gemini) API key used for text classification requests. The backend rejects requests
+  with a 500 error when this value is missing.
+
 The Vertex AI project ID is discovered from the following environment variables in order:
 
 1. `VERTEX_PROJECT_ID`

--- a/cloud-function/index.js
+++ b/cloud-function/index.js
@@ -29,7 +29,14 @@ const TEXT_MODEL = normalizeGeminiModel(process.env.GENAI_MODEL || 'gemini-1.5-f
 
 async function callGemini(model, body) {
   const normalizedModel = normalizeGeminiModel(model || TEXT_MODEL);
-  const apiKey = (process.env.GENAI_API_KEY || '').trim() || 'AIzaSyD95GwAZARg-5Skr0Jw3O0Hh1TlrAfSiSY';
+  const apiKey = (process.env.GENAI_API_KEY || '').trim();
+
+  if (!apiKey) {
+    const error = new Error('GENAI_API_KEY environment variable is not configured.');
+    error.statusCode = 500;
+    throw error;
+  }
+
   const endpoint = `https://generativelanguage.googleapis.com/v1/models/${normalizedModel}:generateContent?key=${apiKey}`;
 
   try {
@@ -43,10 +50,11 @@ async function callGemini(model, body) {
     const statusText = error?.response?.statusText;
     const message = error?.message;
     const data = error?.response?.data;
+    const safeEndpoint = apiKey ? endpoint.replace(apiKey, '***') : endpoint;
     console.error('Gemini request error', {
       status,
       statusText,
-      endpoint,
+      endpoint: safeEndpoint,
       message,
       data
     });

--- a/config.js
+++ b/config.js
@@ -1,11 +1,15 @@
+// Runtime configuration for Codex Vitae.
+// Replace the placeholder values below with your real project settings in a
+// local copy of this file. Do not commit secrets to version control.
 window.__CODEX_CONFIG__ = {
   firebaseConfig: {
-    apiKey: "AIzaSyDqCT_iOBToHDR7sRQnH_mUmwN5V_RXj58",
-    authDomain: "codex-vitae-app.firebaseapp.com",
-    projectId: "codex-vitae-app",
-    storageBucket: "codex-vitae-app.appspot.com",
-    messagingSenderId: "107802832688486",
-    appId: "1:107802832688486:web:3d4c2f40568f6fa4569ad5"
+    apiKey: '',
+    authDomain: '',
+    projectId: '',
+    storageBucket: '',
+    messagingSenderId: '',
+    appId: '',
+    measurementId: ''
   },
-  backendUrl: "https://codex-vitae-backend-1078038224886.us-central1.run.app"
+  backendUrl: ''
 };


### PR DESCRIPTION
## Summary
- remove the fallback Gemini API key and redact logging so secrets are not exposed
- replace the committed frontend config values with placeholders to avoid storing credentials in git
- document the required GENAI_API_KEY environment variable in the backend README

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9b7c71964832194378cbc9fa6aecd