### PR TITLE
Fix Three.js duplication warning and handle missing Firebase config

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,8 @@
     <script type="importmap">
         {
             "imports": {
-                "three": "https://unpkg.com/three@0.160/build/three.module.js"
+                "three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+                "three/examples/jsm/": "https://unpkg.com/three@0.160.0/examples/jsm/"
             }
         }
     </script>

--- a/js/main.js
+++ b/js/main.js
@@ -31,9 +31,8 @@ if (!codexConfig || typeof codexConfig !== 'object') {
         'Codex Vitae configuration is missing.',
         'Define <code>window.__CODEX_CONFIG__</code> in config.js before loading the app.'
     );
-    throw new Error(
-        'Codex Vitae configuration is missing. Define window.__CODEX_CONFIG__ in config.js.'
-    );
+    console.error('Codex Vitae configuration is missing. Define window.__CODEX_CONFIG__ in config.js.');
+    return;
 }
 
 const firebaseConfig = codexConfig.firebaseConfig;
@@ -67,7 +66,10 @@ if (!firebaseConfigIsValid) {
         ? `Missing values for ${missingKeysHtml}. Update <code>config.js</code> with your Firebase project credentials.`
         : 'Update <code>config.js</code> with your Firebase project credentials.';
     displayConfigurationError('Firebase configuration is incomplete.', details);
-    throw new Error('Firebase configuration is incomplete. Update config.js with Firebase project credentials.');
+    console.error('Firebase configuration is incomplete. Update config.js with Firebase project credentials.', {
+        missingKeys: firebaseConfigMissingKeys
+    });
+    return;
 }
 const BACKEND_SERVER_URL =
     typeof codexConfig.backendUrl === 'string' ? codexConfig.backendUrl.trim() : '';
@@ -88,9 +90,8 @@ if (!firebaseConfig || typeof firebaseConfig !== 'object') {
         'Firebase configuration is missing or invalid.',
         'Ensure config.js assigns your Firebase project credentials to <code>firebaseConfig</code>.'
     );
-    throw new Error(
-        'Firebase configuration is missing. Ensure config.js exports firebaseConfig.'
-    );
+    console.error('Firebase configuration is missing. Ensure config.js exports firebaseConfig.');
+    return;
 }
 
 if (!AI_FEATURES_AVAILABLE) {

--- a/js/pipeline/webgl-pipeline.js
+++ b/js/pipeline/webgl-pipeline.js
@@ -1,8 +1,8 @@
-import { EffectComposer } from 'https://unpkg.com/three@0.160/examples/jsm/postprocessing/EffectComposer.js?module';
-import { RenderPass } from 'https://unpkg.com/three@0.160/examples/jsm/postprocessing/RenderPass.js?module';
-import { UnrealBloomPass } from 'https://unpkg.com/three@0.160/examples/jsm/postprocessing/UnrealBloomPass.js?module';
-import { ShaderPass } from 'https://unpkg.com/three@0.160/examples/jsm/postprocessing/ShaderPass.js?module';
-import { RGBELoader } from 'https://unpkg.com/three@0.160/examples/jsm/loaders/RGBELoader.js?module';
+import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
+import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
+import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
+import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 
 window.CVPipeline = Object.assign(window.CVPipeline || {}, {
   EffectComposer, RenderPass, UnrealBloomPass, ShaderPass, RGBELoader,

--- a/js/three-bootstrap.js
+++ b/js/three-bootstrap.js
@@ -1,5 +1,5 @@
-import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
-import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js?module';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 const existingThree = typeof window.THREE === 'object' && window.THREE !== null
     ? window.THREE


### PR DESCRIPTION
## Summary
- align all Three.js imports through the shared import map so only one runtime instance is created
- update the WebGL pipeline helpers to use the shared Three.js modules
- fail gracefully when Firebase configuration is missing by logging the problem and exiting early

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9be37ce0c8321b40e9da55b9fa6c9