### PR TITLE
Add manual chore categorization options and offline fallback

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -72,6 +72,18 @@ p {
     display: none !important;
 }
 
+.visually-hidden {
+    position: absolute !important;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 #auth-screen {
     width: 100%;
     max-width: 360px;
@@ -259,6 +271,49 @@ button:active {
 
 #add-chore-input-group input {
     flex-grow: 1;
+}
+
+#add-chore-input-group select {
+    min-width: 160px;
+    border-radius: 14px;
+    border: 1px solid rgba(86, 100, 108, 0.25);
+    padding: 8px 12px;
+    background: rgba(255, 255, 255, 0.85);
+    color: var(--color-text-dark);
+    font-weight: 600;
+}
+
+.chore-preset-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 14px;
+}
+
+.chore-preset-btn {
+    flex: 1 1 140px;
+    border: none;
+    border-radius: 16px;
+    padding: 10px 14px;
+    background: linear-gradient(140deg, rgba(247, 178, 103, 0.16), rgba(63, 111, 118, 0.1));
+    color: var(--color-primary-dark);
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 10px 22px rgba(63, 111, 118, 0.12);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.chore-preset-btn:hover,
+.chore-preset-btn:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 14px 26px rgba(63, 111, 118, 0.18);
+}
+
+.chore-preset-btn:disabled {
+    opacity: 0.6;
+    cursor: progress;
+    transform: none;
+    box-shadow: 0 8px 16px rgba(63, 111, 118, 0.1);
 }
 
 /* --- FACE SCAN & AVATAR --- */
@@ -779,6 +834,26 @@ model-viewer.avatar-viewer {
     align-items: center;
     padding: 10px 0;
     border-bottom: 1px solid rgba(86, 100, 108, 0.15);
+}
+
+.chore-text-block {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.chore-stat-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: rgba(63, 111, 118, 0.12);
+    color: var(--color-primary-dark);
+    font-size: 0.78em;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    font-weight: 700;
 }
 
 .chore-details {

--- a/index.html
+++ b/index.html
@@ -226,6 +226,73 @@
 
             <div id="add-chore-input-group" class="input-group">
                 <input type="text" id="chore-input" placeholder="Log a completed chore and press Enter...">
+                <label for="chore-stat-select" class="visually-hidden">Select chore stat</label>
+                <select id="chore-stat-select" aria-label="Select a stat for this chore">
+                    <option value="">Auto (AI / keywords)</option>
+                    <option value="pwr">Force</option>
+                    <option value="acc">Precision</option>
+                    <option value="grt">Resilience</option>
+                    <option value="cog">Intellect</option>
+                    <option value="pln">Foresight</option>
+                    <option value="soc">Influence</option>
+                </select>
+            </div>
+
+            <div id="chore-presets" class="chore-preset-grid" role="group" aria-label="Log a preset chore">
+                <button
+                    type="button"
+                    class="chore-preset-btn"
+                    data-chore-preset
+                    data-preset-id="preset-force"
+                    data-chore-text="Completed a strength workout"
+                    data-chore-stat="pwr"
+                    data-chore-effort="12"
+                >Force Workout</button>
+                <button
+                    type="button"
+                    class="chore-preset-btn"
+                    data-chore-preset
+                    data-preset-id="preset-precision"
+                    data-chore-text="Organized and decluttered a space"
+                    data-chore-stat="acc"
+                    data-chore-effort="8"
+                >Precision Organizing</button>
+                <button
+                    type="button"
+                    class="chore-preset-btn"
+                    data-chore-preset
+                    data-preset-id="preset-resilience"
+                    data-chore-text="Finished a deep cleaning session"
+                    data-chore-stat="grt"
+                    data-chore-effort="14"
+                >Resilience Cleaning</button>
+                <button
+                    type="button"
+                    class="chore-preset-btn"
+                    data-chore-preset
+                    data-preset-id="preset-intellect"
+                    data-chore-text="Studied or learned something new"
+                    data-chore-stat="cog"
+                    data-chore-effort="10"
+                >Intellect Study</button>
+                <button
+                    type="button"
+                    class="chore-preset-btn"
+                    data-chore-preset
+                    data-preset-id="preset-foresight"
+                    data-chore-text="Planned the upcoming schedule"
+                    data-chore-stat="pln"
+                    data-chore-effort="9"
+                >Foresight Planning</button>
+                <button
+                    type="button"
+                    class="chore-preset-btn"
+                    data-chore-preset
+                    data-preset-id="preset-influence"
+                    data-chore-text="Reached out to build relationships"
+                    data-chore-stat="soc"
+                    data-chore-effort="7"
+                >Influence Outreach</button>
             </div>
 
             <ul id="chore-list" class="chore-list"></ul>


### PR DESCRIPTION
## Summary
- add a stat selector and preset chore buttons so users can categorize chores without relying on the AI backend
- implement keyword-driven offline classification, manual overrides, and stat badge rendering for chore entries

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d9b345480083219b0a7715948ad5c2