### PR TITLE
Load Firebase config from runtime sources

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,15 +1,154 @@
-// Runtime configuration for Codex Vitae.
-// Replace the placeholder values below with your real project settings in a
-// local copy of this file. Do not commit secrets to version control.
-window.__CODEX_CONFIG__ = {
-  firebaseConfig: {
-    apiKey: '',
-    authDomain: '',
-    projectId: '',
-    storageBucket: '',
-    messagingSenderId: '',
-    appId: '',
-    measurementId: ''
-  },
-  backendUrl: ''
-};
+// Runtime configuration bootstrap for Codex Vitae.
+//
+// This loader keeps secrets out of version control while still allowing the
+// app to run in production. It attempts to hydrate `window.__CODEX_CONFIG__`
+// from a few potential sources:
+//   1. Any configuration that was already assigned to `window.__CODEX_CONFIG__`
+//      before this script executed (for example, an inline script generated
+//      by the hosting platform).
+//   2. A static JSON file (`config.runtime.json`) that can be generated during
+//      deployment with the correct credentials.
+//   3. Firebase Hosting's discovery endpoint (`/__/firebase/init.json`), which
+//      exposes the app's Firebase configuration at runtime without embedding it
+//      in the repository.
+//
+// When a valid configuration is discovered, the loader resolves the
+// `window.__CODEX_CONFIG_READY__` promise so the rest of the app can start
+// safely.
+
+(function bootstrapCodexRuntimeConfig(global) {
+  const REQUIRED_FIREBASE_KEYS = Object.freeze([
+    'apiKey',
+    'authDomain',
+    'projectId',
+    'appId'
+  ]);
+
+  const DEFAULT_CONFIG = Object.freeze({
+    firebaseConfig: {
+      apiKey: '',
+      authDomain: '',
+      projectId: '',
+      storageBucket: '',
+      messagingSenderId: '',
+      appId: '',
+      measurementId: ''
+    },
+    backendUrl: ''
+  });
+
+  function cloneDefaultConfig() {
+    return {
+      firebaseConfig: { ...DEFAULT_CONFIG.firebaseConfig },
+      backendUrl: DEFAULT_CONFIG.backendUrl
+    };
+  }
+
+  function mergeConfig(target, source) {
+    if (!source || typeof source !== 'object') {
+      return target;
+    }
+
+    if (source.firebaseConfig && typeof source.firebaseConfig === 'object') {
+      target.firebaseConfig = target.firebaseConfig || {};
+      for (const key of Object.keys(source.firebaseConfig)) {
+        const value = source.firebaseConfig[key];
+        if (typeof value === 'string') {
+          target.firebaseConfig[key] = value;
+        }
+      }
+    }
+
+    if (typeof source.backendUrl === 'string') {
+      target.backendUrl = source.backendUrl;
+    }
+
+    return target;
+  }
+
+  function hasRequiredFirebaseConfig(config) {
+    if (!config || typeof config !== 'object') {
+      return false;
+    }
+    return REQUIRED_FIREBASE_KEYS.every(key => {
+      const value = config[key];
+      return typeof value === 'string' && value.trim().length > 0;
+    });
+  }
+
+  function finalizeConfig(resolve, baseConfig) {
+    const resolvedConfig = baseConfig || cloneDefaultConfig();
+    global.__CODEX_CONFIG__ = resolvedConfig;
+    resolve(resolvedConfig);
+  }
+
+  const initialConfig = mergeConfig(cloneDefaultConfig(), global.__CODEX_CONFIG__);
+
+  let resolveReady;
+  const readyPromise = new Promise(resolve => {
+    resolveReady = resolve;
+  });
+
+  // Expose the promise immediately so dependent scripts can await it.
+  global.__CODEX_CONFIG_READY__ = readyPromise;
+
+  if (hasRequiredFirebaseConfig(initialConfig.firebaseConfig)) {
+    finalizeConfig(resolveReady, initialConfig);
+    return;
+  }
+
+  const runtimeLoaders = [
+    async function loadFromRuntimeJson() {
+      const response = await fetch('config.runtime.json', { cache: 'no-store' });
+      if (!response.ok) {
+        throw new Error(`config.runtime.json request failed with status ${response.status}`);
+      }
+      const data = await response.json();
+      const normalized = {};
+      if (data && typeof data === 'object') {
+        if (data.firebaseConfig && typeof data.firebaseConfig === 'object') {
+          normalized.firebaseConfig = data.firebaseConfig;
+        } else {
+          normalized.firebaseConfig = data;
+        }
+        if (typeof data.backendUrl === 'string') {
+          normalized.backendUrl = data.backendUrl;
+        }
+      }
+      return normalized;
+    },
+    async function loadFromFirebaseHosting() {
+      const response = await fetch('/__/firebase/init.json', { cache: 'no-store' });
+      if (!response.ok) {
+        throw new Error(`Firebase init.json request failed with status ${response.status}`);
+      }
+      const data = await response.json();
+      if (!data || typeof data !== 'object') {
+        throw new Error('Firebase init.json response did not contain an object.');
+      }
+
+      // Firebase returns the config at the top level. Preserve any existing backendUrl.
+      return { firebaseConfig: data };
+    }
+  ];
+
+  (async () => {
+    const merged = cloneDefaultConfig();
+    mergeConfig(merged, initialConfig);
+
+    for (const loader of runtimeLoaders) {
+      try {
+        const loadedConfig = await loader();
+        mergeConfig(merged, loadedConfig);
+        if (hasRequiredFirebaseConfig(merged.firebaseConfig)) {
+          finalizeConfig(resolveReady, merged);
+          return;
+        }
+      } catch (error) {
+        console.warn('Codex Vitae runtime config loader failed.', error);
+      }
+    }
+
+    finalizeConfig(resolveReady, merged);
+  })();
+})(window);

--- a/js/main.js
+++ b/js/main.js
@@ -1,11 +1,19 @@
 // js/main.js
 
-(() => {
+(async () => {
     'use strict';
 
 // --- CONFIGURATION ---
 // Sensitive configuration values are now injected via config.js which
 // should define window.__CODEX_CONFIG__.
+    const codexConfigReady = window.__CODEX_CONFIG_READY__;
+    if (codexConfigReady && typeof codexConfigReady.then === 'function') {
+        try {
+            await codexConfigReady;
+        } catch (error) {
+            console.error('Failed to resolve Codex Vitae runtime configuration before app start.', error);
+        }
+    }
 function displayConfigurationError(message, details) {
     const authScreenElement = document.getElementById('auth-screen');
     if (!authScreenElement) {


### PR DESCRIPTION
## Summary
- add a configuration bootstrapper that looks for firebase credentials in config.runtime.json or Firebase Hosting
- expose a readiness promise so the app waits for runtime configuration before bootstrapping
- update the main app entrypoint to await the configuration promise before validating settings

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9c5bd8698832192bb3fe2de4c7394