### PR TITLE
Use camelCase system instruction key

### DIFF
--- a/cloud-function/index.js
+++ b/cloud-function/index.js
@@ -84,7 +84,7 @@ app.post('/classify-chore', async (req, res) => {
     }
 
     const response = await callGemini(TEXT_MODEL, {
-      system_instruction: {
+      systemInstruction: {
         role: 'system',
         parts: [
           {


### PR DESCRIPTION
## Summary
- rename the classify-chore request's system instruction property to camelCase to satisfy the Google AI Studio REST schema

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9cefc896883218c3e938ca4326317