### PR TITLE
Add Virtual Me core stat model, star evaluation, docs, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,106 @@
-# Codex Vitae — Sponsored Star Links (Documentation Pack)
+# Virtual Me: Origins
 
-This bundle documents the **Sponsored Star Links** revenue feature. It is designed to be pasted into your repository and referenced by both product and engineering. All files are Markdown, ready for GitHub rendering.
+**Virtual Me: Origins** is a persistent real-life character passport. A user’s habits, achievements, skills, credentials, and personal growth become one portable game-like identity that can travel across games, apps, educational platforms, career systems, and personal development tools.
 
-## Contents
-- Policy & UX principles → `docs/policies/sponsored-star-links-policy.md`
-- Partner-facing one-pager → `docs/partners/sponsor-one-pager.md`
-- Creative specs (partners) → `docs/partners/creative-specs.md`
-- Pricing models (internal + shareable) → `docs/partners/pricing-models.md`
-- Ad tech spec (engineering) → `docs/tech/ad-tech-spec.md`
+> One Character, Many Worlds. Your progress follows you.
 
-## How this fits the codebase
-- Stars have a **Detail Panel**. This pack defines a dedicated **Sponsored options** block with hard caps (e.g., max 3).
-- **Neutrality** is enforced in code: sponsors do not affect Star requirements or ranking of organic options.
-- **Privacy**: share only aggregate metrics with sponsors by default; personal data requires explicit user consent.
-- **Extensibility**: pricing, geo targeting, and format are data-driven via a `sponsored_links` subdocument per Star.
+`Codex Vitae` was the original placeholder name for this repository. Going forward, the product and platform are **Virtual Me: Origins**.
 
-## Quick integration pointers
-- Frontend: add a `SponsoredSection` component (lazy-loaded), with `isSponsored` labeling and CTA buttons.
-- Backend: add `sponsor_campaigns` collection and `star_sponsored_links` mapping; sanitize and validate all fields.
-- Attribution: support UTM params and optional postback webhook; never block Star completion on sponsor availability.
+## Product pillars
 
----
+1. **Game Passport System** — one persistent character profile that can be exported read-only to connected games and experiences.
+2. **Stats, Level-Up & Atrophy** — six universal stats with current performance (`Ability Now`) separated from permanent long-term effort (`Legacy`).
+3. **Skill Universe** — galaxies, constellations, and stars that visualize real skills, milestones, perks, and credentials.
+4. **Cosmic Navigation Experience** — the Skill Universe should feel exploratory, alive, and space-travel inspired.
+5. **Ethical Monetization** — subscriptions, cosmetics, developer licensing, verification services, and contextual brand links without pay-to-win.
 
-© Codex Vitae
+## Canonical stat system
+
+Virtual Me uses six universal stats:
+
+| Stat | Name | Represents |
+| --- | --- | --- |
+| STR | Strength | Physical power and explosive force. |
+| DEX | Dexterity | Accuracy, coordination, fine control, and precision. |
+| CON | Constitution | Endurance, health, discipline, resilience, and stamina. |
+| INT | Intelligence | Learning, reasoning, problem-solving, and analysis. |
+| WIS | Wisdom | Awareness, planning, judgment, intuition, and decision-making. |
+| CHA | Charisma | Communication, leadership, persuasion, influence, and social presence. |
+
+Each stat has two tracks:
+
+- **Ability Now** — current active capability from `0–100`; it can rise or decay based on behavior.
+- **Legacy** — permanent lifetime effort; it never decreases.
+
+Progression rule of thumb: **1,000 fragments = +1 permanent stat point**, and **10 total permanent stat points = +1 character level**.
+
+## Star states
+
+The Skill Universe uses five canonical star states:
+
+| State | Meaning |
+| --- | --- |
+| `LOCKED` | Requirements are not met. |
+| `AVAILABLE` | Requirements are met and the user can unlock or verify the star. |
+| `OWNED` | The star has been unlocked permanently, but activation is not currently required or evaluated. |
+| `ACTIVE` | The star is owned and current Ability Now satisfies activation requirements. |
+| `PAUSED` | The star is owned, but current Ability Now or prerequisites have dropped below activation requirements. |
+
+Ownership is permanent. Activation can pause. Progress is never erased.
+
+## Visual direction
+
+- **Dashboard:** Animus-inspired identity interface — synchronization, memory reconstruction, holographic panels, scanlines, triangulated grids, and diagnostic HUD feedback.
+- **Skill Universe:** No Man’s Sky-inspired space travel — smooth camera movement, cosmic depth, scanner overlays, glowing stars, warp/arrival moments, and living constellations.
+
+## Current technical shape
+
+- Static web app entry: `index.html`
+- Legacy browser controller: `js/main.js`
+- Skill Universe data: `js/skill-tree-data.js`
+- Skill Universe renderer: `js/skill-universe-renderer.js`
+- Tested progression logic: `core/`
+- Backend chore classifier prototype: `cloud-function/`
+- Skill Universe asset pantry: `assets/skill-universe/`
+
+The current codebase is being reset toward the canonical Virtual Me direction. Some older names and internal keys may still exist during migration.
+
+## Local checks
+
+Install dependencies once:
+
+```bash
+npm install
+```
+
+Run the full check suite:
+
+```bash
+npm run check
+```
+
+Run tests only:
+
+```bash
+npm test -- --runInBand
+```
+
+Regenerate the Skill Universe asset manifest after changing material assets:
+
+```bash
+npm run generate:skill-library
+```
+
+## Product rules to preserve
+
+- Never design pay-to-win mechanics.
+- Never allow stat purchases.
+- Never allow skill unlocks through cash.
+- Separate permanent progress from current performance.
+- Legacy never decreases.
+- Ability Now can rise or decay based on real behavior.
+- Unlocking means ownership; current requirements determine activation.
+- Real-world evidence and credentials matter.
+- The user controls data sharing.
+- Developer access should be read-only unless explicitly authorized.
+- Brand links must be optional, contextual, transparent, and non-manipulative.

--- a/__tests__/virtualMe.test.ts
+++ b/__tests__/virtualMe.test.ts
@@ -1,0 +1,182 @@
+import {
+  addLegacyFragments,
+  createEmptyStatMap,
+  createReadOnlyGamePassportExport,
+  createStatTrack,
+  deriveCharacterLevel,
+  evaluateStarState,
+  normalizeStatType,
+  StarDefinition,
+  UserCharacter
+} from '../core/virtualMe';
+
+describe('Virtual Me canonical stat model', () => {
+  it('normalizes canonical stat names and legacy full names', () => {
+    expect(normalizeStatType('STR')).toBe('STR');
+    expect(normalizeStatType('strength')).toBe('STR');
+    expect(normalizeStatType('dexterity')).toBe('DEX');
+    expect(normalizeStatType('charisma')).toBe('CHA');
+    expect(normalizeStatType('unknown')).toBeNull();
+  });
+
+  it('rolls 1,000 fragments into permanent stat points without losing legacy', () => {
+    const starting = createStatTrack('STR', { fragments: 990, legacyPoints: 990, permanentStatPoints: 2 });
+    const result = addLegacyFragments(starting, 25);
+
+    expect(result.statPointsGained).toBe(1);
+    expect(result.track.fragments).toBe(15);
+    expect(result.track.legacyPoints).toBe(1015);
+    expect(result.track.permanentStatPoints).toBe(3);
+  });
+
+  it('derives character level from each 10 total permanent stat points', () => {
+    expect(deriveCharacterLevel(0)).toBe(1);
+    expect(deriveCharacterLevel(9)).toBe(1);
+    expect(deriveCharacterLevel(10)).toBe(2);
+    expect(deriveCharacterLevel(25)).toBe(3);
+  });
+});
+
+describe('Virtual Me star state evaluator', () => {
+  const star: StarDefinition = {
+    id: 'basic-fitness',
+    constellationId: 'body.fitness',
+    name: 'Basic Fitness',
+    description: 'Foundational strength habit.',
+    starType: 'MILESTONE',
+    requirements: {
+      requiredStats: { STR: 40 },
+      prerequisiteStarIds: ['warmup'],
+      perkPointCost: 1
+    }
+  };
+
+  it('returns LOCKED when unlock requirements are unmet', () => {
+    const evaluation = evaluateStarState(star, {
+      abilityNow: { STR: 35 },
+      ownedStarIds: ['warmup'],
+      availablePerkPoints: 1
+    });
+
+    expect(evaluation.state).toBe('LOCKED');
+    expect(evaluation.unmetUnlockRequirements).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: 'STAT', stat: 'STR' })])
+    );
+  });
+
+  it('returns AVAILABLE when requirements are met but the star is not owned', () => {
+    const evaluation = evaluateStarState(star, {
+      abilityNow: { STR: 41 },
+      ownedStarIds: ['warmup'],
+      availablePerkPoints: 1
+    });
+
+    expect(evaluation.state).toBe('AVAILABLE');
+    expect(evaluation.owned).toBe(false);
+  });
+
+  it('returns ACTIVE for owned stars that currently satisfy activation requirements', () => {
+    const evaluation = evaluateStarState(star, {
+      abilityNow: { STR: 41 },
+      ownedStarIds: ['warmup', 'basic-fitness'],
+      availablePerkPoints: 0
+    });
+
+    expect(evaluation.state).toBe('ACTIVE');
+    expect(evaluation.owned).toBe(true);
+    expect(evaluation.active).toBe(true);
+  });
+
+  it('returns PAUSED for owned stars when Ability Now drops below activation requirements', () => {
+    const evaluation = evaluateStarState(star, {
+      abilityNow: { STR: 20 },
+      ownedStarIds: ['warmup', 'basic-fitness'],
+      availablePerkPoints: 0
+    });
+
+    expect(evaluation.state).toBe('PAUSED');
+    expect(evaluation.owned).toBe(true);
+    expect(evaluation.active).toBe(false);
+    expect(evaluation.unmetActivationRequirements).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: 'STAT', stat: 'STR' })])
+    );
+  });
+
+  it('keeps credential stars LOCKED until required evidence is verified', () => {
+    const credentialStar: StarDefinition = {
+      id: 'bachelors-degree',
+      constellationId: 'mind.academics',
+      name: 'Bachelors Degree',
+      description: 'Verified degree credential.',
+      starType: 'CREDENTIAL',
+      requirements: {
+        requiredStats: { INT: 50 },
+        requiredEvidenceTypes: ['degree-document']
+      }
+    };
+
+    expect(
+      evaluateStarState(credentialStar, {
+        abilityNow: { INT: 60 },
+        verifiedEvidenceTypes: []
+      }).state
+    ).toBe('LOCKED');
+
+    expect(
+      evaluateStarState(credentialStar, {
+        abilityNow: { INT: 60 },
+        verifiedEvidenceTypes: ['degree-document']
+      }).state
+    ).toBe('AVAILABLE');
+  });
+
+  it('returns OWNED for owned stars with no activation requirements unless explicitly active', () => {
+    const passiveStar: StarDefinition = {
+      id: 'profile-badge',
+      constellationId: 'identity.badges',
+      name: 'Profile Badge',
+      description: 'A permanent identity marker.',
+      starType: 'MILESTONE'
+    };
+
+    const evaluation = evaluateStarState(passiveStar, {
+      abilityNow: {},
+      ownedStarIds: ['profile-badge']
+    });
+
+    expect(evaluation.state).toBe('OWNED');
+    expect(evaluation.owned).toBe(true);
+    expect(evaluation.active).toBe(false);
+  });
+});
+
+describe('Game Passport export', () => {
+  it('creates a read-only passport export from character state', () => {
+    const stats = createEmptyStatMap(10);
+    stats.STR = createStatTrack('STR', { abilityNow: 55, permanentStatPoints: 4 });
+    const character: UserCharacter = {
+      id: 'character-1',
+      userId: 'user-1',
+      displayName: 'Ezio Tester',
+      level: 1,
+      totalStatPoints: 12,
+      stats,
+      perkPoints: 2,
+      ownedStarIds: ['basic-fitness'],
+      activeStarIds: ['basic-fitness'],
+      verifiedCredentialStarIds: [],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-02T00:00:00.000Z'
+    };
+
+    const passport = createReadOnlyGamePassportExport(character, ['stats:read', 'stars:read']);
+
+    expect(passport.userId).toBe('user-1');
+    expect(passport.characterId).toBe('character-1');
+    expect(passport.level).toBe(2);
+    expect(passport.sharedStats.STR).toEqual({ abilityNow: 55, permanentStatPoints: 4 });
+    expect(passport.sharedStars).toEqual(['basic-fitness']);
+    expect(passport.sharedPerks).toEqual(['basic-fitness']);
+    expect(passport.permissions).toEqual(['stats:read', 'stars:read']);
+  });
+});

--- a/cloud-function/package-lock.json
+++ b/cloud-function/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "codex-vitae-backend",
+  "name": "virtual-me-origins-backend",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "codex-vitae-backend",
+      "name": "virtual-me-origins-backend",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/cloud-function/package.json
+++ b/cloud-function/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "codex-vitae-backend",
+  "name": "virtual-me-origins-backend",
   "version": "1.0.0",
-  "description": "Backend server for the Codex Vitae app.",
+  "description": "Backend server for the Virtual Me: Origins app.",
   "main": "index.js",
   "scripts": {
     "start": "node index.js"

--- a/config.js
+++ b/config.js
@@ -58,13 +58,6 @@
   // can fetch `/__/firebase/init.json` cross-origin without hardcoding secrets.
   const INLINE_RUNTIME_CONFIG = {
     firebaseConfig: {
-      apiKey: 'AIzaSyC11QPS3V1qZNGIQdEYp_Odsy5UoGl-fTo',
-      authDomain: 'codex-vitae-7b7c8.firebaseapp.com',
-      projectId: 'codex-vitae-7b7c8',
-      storageBucket: 'codex-vitae-7b7c8.appspot.com',
-      messagingSenderId: '1078938226885',
-      appId: '1:1078938226885:web:918e532b901f2390173f27',
-      measurementId: 'G-0E0Z4R2T73'
       apiKey: '',
       authDomain: '',
       projectId: '',
@@ -74,7 +67,7 @@
       measurementId: ''
     },
     backendUrl: '',
-    firebaseHostingOrigin: 'https://codex-vitae-470801.web.app'
+    firebaseHostingOrigin: ''
   };
 
   function cloneDefaultConfig() {

--- a/core/virtualMe.ts
+++ b/core/virtualMe.ts
@@ -1,0 +1,300 @@
+export const STAT_TYPES = ['STR', 'DEX', 'CON', 'INT', 'WIS', 'CHA'] as const;
+export type StatType = (typeof STAT_TYPES)[number];
+
+export const STAR_STATES = ['LOCKED', 'AVAILABLE', 'OWNED', 'ACTIVE', 'PAUSED'] as const;
+export type StarState = (typeof STAR_STATES)[number];
+
+export const ABILITY_NOW_MIN = 0;
+export const ABILITY_NOW_MAX = 100;
+export const LEGACY_FRAGMENTS_PER_STAT_POINT = 1000;
+export const STAT_POINTS_PER_CHARACTER_LEVEL = 10;
+
+export interface StatTrack {
+  type: StatType;
+  abilityNow: number;
+  legacyPoints: number;
+  permanentStatPoints: number;
+  fragments: number;
+  lastActivityAt?: string;
+  decayStatus?: 'STABLE' | 'AT_RISK' | 'DECAYING' | 'RECOVERING';
+  maintenanceThreshold?: number;
+}
+
+export interface UserCharacter {
+  id: string;
+  userId: string;
+  displayName: string;
+  level: number;
+  totalStatPoints: number;
+  stats: Record<StatType, StatTrack>;
+  perkPoints: number;
+  ownedStarIds: string[];
+  activeStarIds: string[];
+  verifiedCredentialStarIds: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type StarType = 'MILESTONE' | 'APEX' | 'CREDENTIAL';
+
+export interface StarRequirements {
+  requiredStats?: Partial<Record<StatType, number>>;
+  prerequisiteStarIds?: string[];
+  requiredEvidenceTypes?: string[];
+  perkPointCost?: number;
+}
+
+export interface StarDefinition {
+  id: string;
+  constellationId: string;
+  name: string;
+  description: string;
+  starType: StarType;
+  requirements?: StarRequirements;
+  activationRequirements?: StarRequirements;
+  brandLinks?: string[];
+}
+
+export interface StarEvaluationContext {
+  abilityNow: Partial<Record<StatType, number>>;
+  ownedStarIds?: string[];
+  activeStarIds?: string[];
+  verifiedCredentialStarIds?: string[];
+  verifiedEvidenceTypes?: string[];
+  availablePerkPoints?: number;
+}
+
+export interface RequirementFailure {
+  type: 'STAT' | 'PREREQUISITE_STAR' | 'EVIDENCE' | 'PERK_POINT';
+  stat?: StatType;
+  required?: number;
+  current?: number;
+  starId?: string;
+  evidenceType?: string;
+  requiredPoints?: number;
+  availablePoints?: number;
+}
+
+export interface StarEvaluationResult {
+  state: StarState;
+  owned: boolean;
+  active: boolean;
+  unmetUnlockRequirements: RequirementFailure[];
+  unmetActivationRequirements: RequirementFailure[];
+}
+
+const LEGACY_STAT_ALIASES: Record<string, StatType> = {
+  STRENGTH: 'STR',
+  STR: 'STR',
+  DEXTERITY: 'DEX',
+  DEX: 'DEX',
+  CONSTITUTION: 'CON',
+  CON: 'CON',
+  INTELLIGENCE: 'INT',
+  INT: 'INT',
+  WISDOM: 'WIS',
+  WIS: 'WIS',
+  CHARISMA: 'CHA',
+  CHA: 'CHA'
+};
+
+export function normalizeStatType(value: string): StatType | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.trim().toUpperCase();
+  return LEGACY_STAT_ALIASES[normalized] ?? null;
+}
+
+export function clampAbilityNow(value: number): number {
+  if (!Number.isFinite(value)) {
+    return ABILITY_NOW_MIN;
+  }
+  return Math.max(ABILITY_NOW_MIN, Math.min(ABILITY_NOW_MAX, Math.round(value)));
+}
+
+export function normalizeFragments(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(LEGACY_FRAGMENTS_PER_STAT_POINT - 1, Math.floor(value)));
+}
+
+export function createStatTrack(type: StatType, overrides: Partial<StatTrack> = {}): StatTrack {
+  return {
+    type,
+    abilityNow: clampAbilityNow(overrides.abilityNow ?? 0),
+    legacyPoints: Math.max(0, Math.floor(overrides.legacyPoints ?? 0)),
+    permanentStatPoints: Math.max(0, Math.floor(overrides.permanentStatPoints ?? 0)),
+    fragments: normalizeFragments(overrides.fragments ?? 0),
+    lastActivityAt: overrides.lastActivityAt,
+    decayStatus: overrides.decayStatus,
+    maintenanceThreshold: Number.isFinite(overrides.maintenanceThreshold)
+      ? Math.max(0, Number(overrides.maintenanceThreshold))
+      : undefined
+  };
+}
+
+export function createEmptyStatMap(defaultAbilityNow = 0): Record<StatType, StatTrack> {
+  return STAT_TYPES.reduce((stats, type) => {
+    stats[type] = createStatTrack(type, { abilityNow: defaultAbilityNow });
+    return stats;
+  }, {} as Record<StatType, StatTrack>);
+}
+
+export function deriveCharacterLevel(totalStatPoints: number): number {
+  if (!Number.isFinite(totalStatPoints) || totalStatPoints <= 0) {
+    return 1;
+  }
+  return Math.floor(totalStatPoints / STAT_POINTS_PER_CHARACTER_LEVEL) + 1;
+}
+
+export function addLegacyFragments(track: StatTrack, amount: number): { track: StatTrack; statPointsGained: number } {
+  const safeAmount = Number.isFinite(amount) ? Math.max(0, Math.floor(amount)) : 0;
+  const rawFragments = normalizeFragments(track.fragments) + safeAmount;
+  const statPointsGained = Math.floor(rawFragments / LEGACY_FRAGMENTS_PER_STAT_POINT);
+  const fragments = rawFragments % LEGACY_FRAGMENTS_PER_STAT_POINT;
+  const legacyPoints = Math.max(0, Math.floor(track.legacyPoints || 0)) + safeAmount;
+  const permanentStatPoints = Math.max(0, Math.floor(track.permanentStatPoints || 0)) + statPointsGained;
+
+  return {
+    statPointsGained,
+    track: createStatTrack(track.type, {
+      ...track,
+      fragments,
+      legacyPoints,
+      permanentStatPoints
+    })
+  };
+}
+
+function evaluateRequirements(
+  requirements: StarRequirements | undefined,
+  context: StarEvaluationContext,
+  options: { includePerkCost: boolean; includeEvidence: boolean }
+): RequirementFailure[] {
+  const failures: RequirementFailure[] = [];
+  const req = requirements ?? {};
+  const ownedStarIds = new Set(context.ownedStarIds ?? []);
+  const verifiedEvidenceTypes = new Set(context.verifiedEvidenceTypes ?? []);
+
+  for (const [rawStat, requiredValue] of Object.entries(req.requiredStats ?? {})) {
+    const stat = normalizeStatType(rawStat);
+    if (!stat || requiredValue === undefined) {
+      continue;
+    }
+    const required = Math.max(0, Number(requiredValue));
+    const current = clampAbilityNow(context.abilityNow[stat] ?? 0);
+    if (current < required) {
+      failures.push({ type: 'STAT', stat, required, current });
+    }
+  }
+
+  for (const starId of req.prerequisiteStarIds ?? []) {
+    if (!ownedStarIds.has(starId)) {
+      failures.push({ type: 'PREREQUISITE_STAR', starId });
+    }
+  }
+
+  if (options.includeEvidence) {
+    for (const evidenceType of req.requiredEvidenceTypes ?? []) {
+      if (!verifiedEvidenceTypes.has(evidenceType)) {
+        failures.push({ type: 'EVIDENCE', evidenceType });
+      }
+    }
+  }
+
+  if (options.includePerkCost && Number.isFinite(req.perkPointCost) && Number(req.perkPointCost) > 0) {
+    const requiredPoints = Math.max(0, Math.floor(Number(req.perkPointCost)));
+    const availablePoints = Math.max(0, Math.floor(context.availablePerkPoints ?? 0));
+    if (availablePoints < requiredPoints) {
+      failures.push({ type: 'PERK_POINT', requiredPoints, availablePoints });
+    }
+  }
+
+  return failures;
+}
+
+export function evaluateStarState(star: StarDefinition, context: StarEvaluationContext): StarEvaluationResult {
+  const ownedStarIds = new Set(context.ownedStarIds ?? []);
+  const activeStarIds = new Set(context.activeStarIds ?? []);
+  const owned = ownedStarIds.has(star.id);
+
+  const unmetUnlockRequirements = evaluateRequirements(star.requirements, context, {
+    includePerkCost: true,
+    includeEvidence: true
+  });
+
+  if (!owned) {
+    return {
+      state: unmetUnlockRequirements.length === 0 ? 'AVAILABLE' : 'LOCKED',
+      owned: false,
+      active: false,
+      unmetUnlockRequirements,
+      unmetActivationRequirements: []
+    };
+  }
+
+  const activationRequirements = star.activationRequirements ?? star.requirements;
+  const unmetActivationRequirements = evaluateRequirements(activationRequirements, context, {
+    includePerkCost: false,
+    includeEvidence: false
+  });
+  const active = unmetActivationRequirements.length === 0;
+
+  if (!activationRequirements || Object.keys(activationRequirements).length === 0) {
+    return {
+      state: activeStarIds.has(star.id) ? 'ACTIVE' : 'OWNED',
+      owned: true,
+      active: activeStarIds.has(star.id),
+      unmetUnlockRequirements: [],
+      unmetActivationRequirements: []
+    };
+  }
+
+  return {
+    state: active ? 'ACTIVE' : 'PAUSED',
+    owned: true,
+    active,
+    unmetUnlockRequirements: [],
+    unmetActivationRequirements
+  };
+}
+
+export interface GamePassportExport {
+  userId: string;
+  characterId: string;
+  displayName: string;
+  level: number;
+  sharedStats: Record<StatType, { abilityNow: number; permanentStatPoints: number }>;
+  sharedStars: string[];
+  sharedPerks: string[];
+  permissions: string[];
+  exportedAt: string;
+}
+
+export function createReadOnlyGamePassportExport(
+  character: UserCharacter,
+  permissions: string[] = []
+): GamePassportExport {
+  const sharedStats = STAT_TYPES.reduce((stats, type) => {
+    const track = character.stats[type] ?? createStatTrack(type);
+    stats[type] = {
+      abilityNow: clampAbilityNow(track.abilityNow),
+      permanentStatPoints: Math.max(0, Math.floor(track.permanentStatPoints || 0))
+    };
+    return stats;
+  }, {} as GamePassportExport['sharedStats']);
+
+  return {
+    userId: character.userId,
+    characterId: character.id,
+    displayName: character.displayName,
+    level: deriveCharacterLevel(character.totalStatPoints),
+    sharedStats,
+    sharedStars: [...character.ownedStarIds],
+    sharedPerks: [...character.activeStarIds],
+    permissions: [...permissions],
+    exportedAt: new Date().toISOString()
+  };
+}

--- a/docs/PRODUCT_CODEX.md
+++ b/docs/PRODUCT_CODEX.md
@@ -1,0 +1,186 @@
+# Virtual Me: Origins Product Codex
+
+This document is the canonical direction for the reset of the former Codex Vitae prototype. **Virtual Me: Origins** is the product name for the platform, app, and identity system.
+
+## North Star
+
+**One Character, Many Worlds. Your progress follows you.**
+
+Virtual Me: Origins is a real-life character identity infrastructure layer. A user’s actual habits, achievements, skills, credentials, and personal growth become a persistent game-like identity that can connect to games, apps, education, career systems, and personal development tools.
+
+The player is the save file.
+
+## 1. Game Passport System
+
+The Game Passport gives each user one persistent character profile that stores:
+
+- six universal stats: STR, DEX, CON, INT, WIS, CHA;
+- Ability Now values;
+- Legacy values;
+- Skill Universe progress;
+- unlocked, owned, active, and paused stars/perks;
+- achievements;
+- verified credentials;
+- history and activity logs;
+- privacy permissions for connected experiences.
+
+Connected games should read the passport with user permission and adapt their experience without manual setup. Games can interpret the same stats differently by genre through soft caps, scaling curves, stat mappings, and star mappings.
+
+Developer integration principles:
+
+- open;
+- modular;
+- optional;
+- read-only by default;
+- opt-in per game;
+- flexible for RPGs, strategy games, simulations, narrative games, and other genres.
+
+Security and trust principles:
+
+- only authentic progress should count;
+- no stat editing or stat injection;
+- verified credentials matter;
+- anti-cheat and fraud detection are required for competitive contexts;
+- the player controls what data is shared.
+
+## 2. Stat, Level-Up & Atrophy System
+
+Core philosophy: **Growth, not grinding.**
+
+Stats represent foundational human capacities, not narrow isolated skills.
+
+| Stat | Name | Represents |
+| --- | --- | --- |
+| STR | Strength | Physical strength and explosive power. |
+| DEX | Dexterity | Accuracy, fine control, coordination, and precision. |
+| CON | Constitution | Endurance, health, discipline, resilience, and stamina. |
+| INT | Intelligence | Learning, reasoning, problem-solving, and analytical thinking. |
+| WIS | Wisdom | Awareness, planning, judgment, intuition, and decision-making. |
+| CHA | Charisma | Communication, leadership, persuasion, influence, and social presence. |
+
+Each stat has two parallel tracks:
+
+### Ability Now
+
+- Range: `0–100`.
+- Represents current active capability.
+- Responds quickly to behavior changes.
+- Can increase or decrease over time.
+- Used for perk activation, gameplay checks, and moment-to-moment performance.
+
+### Legacy
+
+- Permanent long-term record of effort.
+- Each stat has its own Legacy track.
+- Never decreases.
+- Represents accumulated effort over time.
+- Used for permanent stat increases, perk ownership, and mastery recognition.
+
+Stat growth flow:
+
+1. The user logs a real activity or habit.
+2. The activity is classified to a stat.
+3. Effort generates stat fragments.
+4. `1,000 fragments = +1 permanent stat point`.
+5. `10 total permanent stat points = +1 character level`.
+
+Atrophy affects Ability Now only. Higher stats require more maintenance. Legacy is never affected by atrophy.
+
+## 3. Skill Universe System
+
+The Skill Universe is a living map of who the user is becoming.
+
+Hierarchy:
+
+- **Galaxy** — a major domain of life, such as Mind, Body, Soul, or Social.
+- **Constellation** — a themed path inside a galaxy.
+- **Star** — an individual skill, perk, verified achievement, milestone, or apex accomplishment.
+
+Star types:
+
+- **Milestone Stars** — foundational or intermediate progress.
+- **Apex Stars** — rare peak achievements that define identity and specialization.
+- **Credential Stars** — achievements requiring evidence or verification.
+
+Canonical star states:
+
+| State | Meaning |
+| --- | --- |
+| `LOCKED` | Requirements are not met. |
+| `AVAILABLE` | Requirements are met and the user can unlock or verify the star. |
+| `OWNED` | The star is permanently unlocked, but activation is not currently evaluated or required. |
+| `ACTIVE` | The star is owned and current requirements are satisfied. |
+| `PAUSED` | The star is owned, but current Ability Now or prerequisite requirements are not currently satisfied. |
+
+Ownership vs activation is mandatory:
+
+- unlocking means ownership;
+- activation depends on current requirements;
+- if Ability Now drops below requirements, the star or perk pauses;
+- paused progress is not erased.
+
+## 4. Visual / Navigation Experience
+
+Dashboard target: **Animus-inspired identity interface**.
+
+- synchronization language;
+- memory reconstruction;
+- holographic panels;
+- scanlines;
+- triangulated grids;
+- diagnostic HUD notifications;
+- high-trust system feel.
+
+Skill Universe target: **No Man’s Sky-inspired cosmic exploration**.
+
+- fully navigable space;
+- smooth camera travel through Galaxy → Constellation → Star;
+- no hard cuts;
+- stars pulse, connect, and light up;
+- warm glow for available stars;
+- cool vibrant light for active/unlocked stars;
+- locked stars are dim and distant;
+- scanner overlays and warp/arrival moments.
+
+The visual experience is identity visualization, not normal UI.
+
+## 5. Monetization Rules
+
+Monetization must protect trust.
+
+Never allow:
+
+- pay-to-win mechanics;
+- stat purchases;
+- cash skill unlocks;
+- brand manipulation of progression;
+- behavioral targeting;
+- forced brand engagement.
+
+Allowed monetization pillars:
+
+- optional player subscriptions for analytics, history, verification speed, and customization;
+- developer licensing and SDK/API access;
+- cosmetic and identity customization;
+- marketplace fees for visual packs and profile presentation;
+- contextual brand links that are optional, transparent, capped, and relevant;
+- credential and verification services;
+- enterprise and institutional licensing.
+
+## MVP Priority
+
+1. Core character profile.
+2. Six stats: STR, DEX, CON, INT, WIS, CHA.
+3. Ability Now and Legacy separation.
+4. Activity logging.
+5. Fragment-to-stat conversion.
+6. Basic level calculation.
+7. Basic Skill Universe hierarchy.
+8. Star states: LOCKED, AVAILABLE, OWNED, ACTIVE, PAUSED.
+9. Stat requirements for stars.
+10. Perk Point spending.
+11. Simple visual Skill Universe map.
+12. Read-only Game Passport export.
+13. Privacy/data sharing controls.
+
+Monetization should not lead the build. The foundation is trust, progression, and identity.

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "codex-vitae",
+  "name": "virtual-me-origins",
   "version": "1.0.0",
-  "description": "Codex Vitae web app",
+  "description": "Virtual Me: Origins web app",
   "scripts": {
     "test": "jest",
-    "generate:skill-library": "node tools/build-skill-universe-library.js"
+    "generate:skill-library": "node tools/build-skill-universe-library.js",
+    "check": "node --check config.js && node --check js/main.js && node --check js/skill-tree-data.js && node --check js/skill-universe-star-mixer.js && node --check js/skill-universe-renderer.js && node --check cloud-function/index.js && tsc --noEmit && npm test -- --runInBand"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",


### PR DESCRIPTION
### Motivation
- Rename and reset the prototype to the new product identity `Virtual Me: Origins` and remove legacy placeholder names and secrets. 
- Provide a canonical stat/leveling model and star lifecycle so the platform can reason about ownership, activation, and credential verification. 
- Ship a read-only Game Passport export format to enable safe sharing with connected games and experiences. 

### Description
- Implement a new core library at `core/virtualMe.ts` that defines `StatType`, `StatTrack`, stat normalization, fragment rollup (`addLegacyFragments`), `deriveCharacterLevel`, star requirement evaluation (`evaluateStarState`), and `createReadOnlyGamePassportExport`.
- Add comprehensive unit tests in `__tests__/virtualMe.test.ts` that cover stat normalization, fragment conversion to permanent stat points, level derivation, star state evaluation across states (`LOCKED`, `AVAILABLE`, `OWNED`, `ACTIVE`, `PAUSED`), credential evidence checks, and passport export fields.
- Replace product identifiers and documentation: update `README.md` to `Virtual Me: Origins`, add `docs/PRODUCT_CODEX.md` with product pillars and rules, and rename packages in `package.json` and `cloud-function/package.json` to `virtual-me-origins` variants.
- Remove hardcoded Firebase credentials from `config.js` (blanked out) and add a `check` script to `package.json` to run quick local validations and static checks (`node --check`, `tsc --noEmit`, and tests).

### Testing
- Added Jest unit tests in `__tests__/virtualMe.test.ts` that exercise stat utilities, fragment rollup, level calculation, star evaluation, credential handling, and passport export, and these tests were executed via `npm test` and passed.
- Static checks are supported by the new `npm run check` composite script which includes `tsc --noEmit` and `npm test -- --runInBand` for local validation (script added but not asserted here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a07dae706848328b790d0ae7fd0f34b)