### PR TITLE
Virtual Me: Origins — product rename, Animus UI theme, core stat model, and tests

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -1249,3 +1249,390 @@ model-viewer.avatar-viewer {
         margin-left: 0;
     }
 }
+
+/* --- Virtual Me: Origins Animus dashboard shell --- */
+:root {
+    --animus-bg: #03070c;
+    --animus-panel: rgba(6, 18, 28, 0.78);
+    --animus-panel-strong: rgba(8, 28, 42, 0.92);
+    --animus-cyan: #7df9ff;
+    --animus-cyan-soft: rgba(125, 249, 255, 0.28);
+    --animus-cyan-faint: rgba(125, 249, 255, 0.12);
+    --animus-white: #edfaff;
+    --animus-muted: rgba(206, 232, 242, 0.72);
+    --animus-warning: #ffcc66;
+    --animus-danger: #ff6b7a;
+    --animus-grid: rgba(125, 249, 255, 0.08);
+}
+
+body {
+    min-height: 100vh;
+    padding: 28px;
+    align-items: stretch;
+    justify-content: center;
+    color: var(--animus-white);
+    background:
+        radial-gradient(circle at 50% 20%, rgba(58, 196, 255, 0.18), transparent 34%),
+        radial-gradient(circle at 85% 80%, rgba(255, 255, 255, 0.08), transparent 30%),
+        linear-gradient(135deg, #010308 0%, #071521 48%, #02050a 100%);
+    overflow-x: hidden;
+}
+
+body::before {
+    background:
+        linear-gradient(var(--animus-grid) 1px, transparent 1px),
+        linear-gradient(90deg, var(--animus-grid) 1px, transparent 1px),
+        radial-gradient(circle at 12% 18%, rgba(125, 249, 255, 0.14), transparent 24%),
+        radial-gradient(circle at 82% 12%, rgba(255, 255, 255, 0.08), transparent 28%);
+    background-size: 42px 42px, 42px 42px, auto, auto;
+    opacity: 0.9;
+    z-index: -2;
+}
+
+body::after {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background:
+        repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.045) 0 1px, transparent 1px 5px),
+        linear-gradient(90deg, transparent, rgba(125, 249, 255, 0.08), transparent);
+    mix-blend-mode: screen;
+    opacity: 0.34;
+    z-index: 2000;
+}
+
+#auth-screen {
+    margin: auto;
+    background: linear-gradient(150deg, rgba(5, 18, 28, 0.92), rgba(6, 32, 46, 0.76));
+    border: 1px solid var(--animus-cyan-soft);
+    border-radius: 4px;
+    box-shadow: 0 0 48px rgba(125, 249, 255, 0.16), inset 0 0 32px rgba(125, 249, 255, 0.06);
+    color: var(--animus-white);
+}
+
+#auth-screen h1,
+#app-screen h2,
+#app-screen h3,
+#app-screen h4,
+.modal-content h2 {
+    color: var(--animus-white);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+}
+
+#app-screen {
+    width: min(1560px, 100%);
+    max-width: none;
+    min-height: calc(100vh - 56px);
+    display: grid;
+    grid-template-columns: minmax(280px, 0.9fr) minmax(360px, 1.25fr) minmax(320px, 1fr);
+    grid-template-areas:
+        "header header header"
+        "legacy avatar maintenance"
+        "stats avatar perks"
+        "stats scan chores"
+        "nav nav nav";
+    gap: 18px;
+    padding: 22px;
+    background:
+        linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 18%),
+        linear-gradient(155deg, rgba(4, 14, 22, 0.94), rgba(6, 22, 34, 0.72));
+    border: 1px solid var(--animus-cyan-soft);
+    border-radius: 6px;
+    box-shadow:
+        0 0 70px rgba(125, 249, 255, 0.12),
+        inset 0 0 42px rgba(125, 249, 255, 0.05);
+    backdrop-filter: blur(14px);
+    position: relative;
+    overflow: hidden;
+}
+
+#app-screen::before,
+#app-screen::after {
+    content: "";
+    position: absolute;
+    pointer-events: none;
+    z-index: 0;
+}
+
+#app-screen::before {
+    inset: 12px;
+    border: 1px solid rgba(125, 249, 255, 0.12);
+    clip-path: polygon(0 0, 21% 0, 24% 6px, 76% 6px, 79% 0, 100% 0, 100% 100%, 0 100%);
+}
+
+#app-screen::after {
+    inset: 0;
+    background:
+        linear-gradient(120deg, transparent 0 18%, rgba(125, 249, 255, 0.08) 18.15%, transparent 18.3% 64%, rgba(125, 249, 255, 0.06) 64.1%, transparent 64.25%),
+        radial-gradient(circle at 50% 42%, rgba(125, 249, 255, 0.12), transparent 32%);
+    opacity: 0.8;
+}
+
+#app-screen > * {
+    position: relative;
+    z-index: 1;
+}
+
+.animus-shell-header {
+    grid-area: header;
+    padding: 18px 22px;
+    border: 1px solid var(--animus-cyan-soft);
+    background: linear-gradient(90deg, rgba(125, 249, 255, 0.12), rgba(6, 18, 28, 0.7) 42%, rgba(125, 249, 255, 0.08));
+    box-shadow: inset 0 -1px 0 rgba(125, 249, 255, 0.24);
+}
+
+.animus-shell-header h2 {
+    margin: 4px 0;
+    text-align: left;
+    font-size: clamp(1.7rem, 3vw, 3.4rem);
+    line-height: 1;
+}
+
+.animus-shell-header p,
+.animus-kicker {
+    color: var(--animus-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    font-size: 0.78rem;
+}
+
+#legacy-level-section { grid-area: legacy; }
+#stat-panel { grid-area: stats; }
+.avatar-hero { grid-area: avatar; }
+#face-scan-section { grid-area: scan; align-self: start; }
+#maintenance-card { grid-area: maintenance; }
+#perk-panel { grid-area: perks; }
+#chore-section { grid-area: chores; }
+#open-codex-btn { grid-area: nav; justify-self: center; min-width: min(420px, 100%); }
+
+.widget,
+.modal-content,
+.stat-card,
+.perk-overview-card,
+.perk-progress-card {
+    background: linear-gradient(160deg, rgba(4, 20, 31, 0.86), rgba(3, 12, 20, 0.66));
+    border: 1px solid var(--animus-cyan-soft);
+    border-radius: 4px;
+    box-shadow: 0 0 30px rgba(125, 249, 255, 0.08), inset 0 0 22px rgba(125, 249, 255, 0.035);
+    color: var(--animus-white);
+}
+
+.widget::before {
+    background:
+        linear-gradient(90deg, var(--animus-cyan-soft), transparent 36%),
+        linear-gradient(180deg, rgba(255, 255, 255, 0.08), transparent 42%);
+    opacity: 0.55;
+}
+
+.widget > *,
+.stat-card > *,
+.perk-overview-card > *,
+.perk-progress-card > * {
+    position: relative;
+    z-index: 1;
+}
+
+.widget h3,
+.widget h4 {
+    text-align: left;
+    margin-top: 0;
+    color: var(--animus-white);
+    text-shadow: 0 0 14px rgba(125, 249, 255, 0.28);
+}
+
+.widget-subtitle,
+.meta-label,
+.legacy-progress-text,
+.legacy-counter,
+.stat-confidence,
+.perk-progress-text,
+.empty-state,
+.chore-details {
+    color: var(--animus-muted);
+}
+
+.avatar-hero {
+    min-height: 590px;
+    border: 1px solid var(--animus-cyan-soft);
+    border-radius: 4px;
+    background:
+        radial-gradient(circle at 50% 34%, rgba(125, 249, 255, 0.18), transparent 31%),
+        linear-gradient(180deg, rgba(255, 255, 255, 0.04), transparent 44%),
+        rgba(2, 10, 18, 0.74);
+    box-shadow: inset 0 0 70px rgba(125, 249, 255, 0.08), 0 0 42px rgba(125, 249, 255, 0.12);
+}
+
+.avatar-hero::before {
+    background:
+        repeating-radial-gradient(circle at 50% 42%, transparent 0 44px, rgba(125, 249, 255, 0.12) 45px 46px),
+        linear-gradient(90deg, transparent 49.8%, rgba(125, 249, 255, 0.28) 50%, transparent 50.2%),
+        linear-gradient(0deg, transparent 49.8%, rgba(125, 249, 255, 0.2) 50%, transparent 50.2%);
+    opacity: 0.8;
+}
+
+.avatar-hero::after {
+    background: radial-gradient(circle at 50% 38%, rgba(237, 250, 255, 0.2), transparent 58%);
+}
+
+.avatar-stage,
+.avatar-stage.is-placeholder {
+    border-radius: 50%;
+    border: 1px solid var(--animus-cyan-soft);
+    background:
+        radial-gradient(circle at 50% 26%, rgba(237, 250, 255, 0.32), transparent 19%),
+        radial-gradient(circle at 50% 56%, rgba(125, 249, 255, 0.18), transparent 44%),
+        rgba(2, 12, 20, 0.72);
+    box-shadow: 0 0 54px rgba(125, 249, 255, 0.18), inset 0 0 34px rgba(125, 249, 255, 0.08);
+}
+
+.avatar-stage.is-placeholder::before {
+    background:
+        linear-gradient(90deg, transparent 49%, rgba(125, 249, 255, 0.45) 50%, transparent 51%),
+        linear-gradient(0deg, transparent 49%, rgba(125, 249, 255, 0.35) 50%, transparent 51%),
+        radial-gradient(circle, transparent 52%, rgba(125, 249, 255, 0.18) 53%, transparent 58%);
+}
+
+input,
+select,
+button {
+    background: rgba(3, 15, 24, 0.86);
+    color: var(--animus-white);
+    border: 1px solid rgba(125, 249, 255, 0.22);
+    border-radius: 2px;
+}
+
+button,
+#open-codex-btn,
+#skill-search-form button {
+    background: linear-gradient(135deg, rgba(125, 249, 255, 0.18), rgba(125, 249, 255, 0.42));
+    color: var(--animus-white);
+    border: 1px solid rgba(125, 249, 255, 0.5);
+    box-shadow: 0 0 22px rgba(125, 249, 255, 0.18), inset 0 0 14px rgba(125, 249, 255, 0.08);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+button:hover,
+#open-codex-btn:hover {
+    box-shadow: 0 0 34px rgba(125, 249, 255, 0.32), inset 0 0 18px rgba(125, 249, 255, 0.12);
+}
+
+.stat-bar,
+.progress-bar-container,
+.legacy-progress-track {
+    background: rgba(125, 249, 255, 0.08);
+    border: 1px solid rgba(125, 249, 255, 0.16);
+    border-radius: 2px;
+}
+
+.stat-bar-fill,
+.progress-bar,
+.legacy-progress-fill {
+    background: linear-gradient(90deg, rgba(125, 249, 255, 0.22), rgba(125, 249, 255, 0.92), rgba(237, 250, 255, 0.7));
+    box-shadow: 0 0 18px rgba(125, 249, 255, 0.34);
+}
+
+.stat-bar.legacy .stat-bar-fill {
+    background: linear-gradient(90deg, rgba(255, 204, 102, 0.25), rgba(255, 204, 102, 0.88));
+}
+
+.chore-preset-btn,
+.chore-item,
+.chore-stat-badge {
+    background: rgba(125, 249, 255, 0.08);
+    border-color: rgba(125, 249, 255, 0.18);
+    color: var(--animus-white);
+}
+
+.hud-toast-region {
+    position: fixed;
+    right: 24px;
+    bottom: 24px;
+    z-index: 2200;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    width: min(380px, calc(100vw - 32px));
+    pointer-events: none;
+}
+
+.hud-toast {
+    padding: 14px 16px;
+    border: 1px solid var(--animus-cyan-soft);
+    border-left: 4px solid var(--animus-cyan);
+    background: linear-gradient(135deg, rgba(4, 20, 31, 0.96), rgba(5, 33, 48, 0.88));
+    color: var(--animus-white);
+    box-shadow: 0 0 28px rgba(125, 249, 255, 0.18);
+    transform: translateX(0);
+    opacity: 1;
+    transition: opacity 0.24s ease, transform 0.24s ease;
+}
+
+.hud-toast[data-variant="warning"] {
+    border-left-color: var(--animus-warning);
+}
+
+.hud-toast.is-dismissing {
+    opacity: 0;
+    transform: translateX(16px);
+}
+
+.hud-toast-label,
+.hud-toast-message {
+    display: block;
+}
+
+.hud-toast-label {
+    color: var(--animus-cyan);
+    font-size: 0.68rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    margin-bottom: 4px;
+}
+
+.hud-toast-message {
+    color: var(--animus-white);
+    line-height: 1.35;
+}
+
+@media (max-width: 980px) {
+    body {
+        padding: 18px;
+    }
+
+    #app-screen {
+        min-height: auto;
+        grid-template-columns: 1fr;
+        grid-template-areas:
+            "header"
+            "avatar"
+            "scan"
+            "legacy"
+            "stats"
+            "maintenance"
+            "perks"
+            "chores"
+            "nav";
+    }
+
+    .avatar-hero {
+        min-height: 430px;
+    }
+}
+
+@media (max-width: 520px) {
+    body {
+        padding: 12px;
+    }
+
+    #app-screen {
+        padding: 14px;
+    }
+
+    .hud-toast-region {
+        right: 16px;
+        bottom: 16px;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,25 +1,106 @@
-# Codex Vitae — Sponsored Star Links (Documentation Pack)
+# Virtual Me: Origins
 
-This bundle documents the **Sponsored Star Links** revenue feature. It is designed to be pasted into your repository and referenced by both product and engineering. All files are Markdown, ready for GitHub rendering.
+**Virtual Me: Origins** is a persistent real-life character passport. A user’s habits, achievements, skills, credentials, and personal growth become one portable game-like identity that can travel across games, apps, educational platforms, career systems, and personal development tools.
 
-## Contents
-- Policy & UX principles → `docs/policies/sponsored-star-links-policy.md`
-- Partner-facing one-pager → `docs/partners/sponsor-one-pager.md`
-- Creative specs (partners) → `docs/partners/creative-specs.md`
-- Pricing models (internal + shareable) → `docs/partners/pricing-models.md`
-- Ad tech spec (engineering) → `docs/tech/ad-tech-spec.md`
+> One Character, Many Worlds. Your progress follows you.
 
-## How this fits the codebase
-- Stars have a **Detail Panel**. This pack defines a dedicated **Sponsored options** block with hard caps (e.g., max 3).
-- **Neutrality** is enforced in code: sponsors do not affect Star requirements or ranking of organic options.
-- **Privacy**: share only aggregate metrics with sponsors by default; personal data requires explicit user consent.
-- **Extensibility**: pricing, geo targeting, and format are data-driven via a `sponsored_links` subdocument per Star.
+`Codex Vitae` was the original placeholder name for this repository. Going forward, the product and platform are **Virtual Me: Origins**.
 
-## Quick integration pointers
-- Frontend: add a `SponsoredSection` component (lazy-loaded), with `isSponsored` labeling and CTA buttons.
-- Backend: add `sponsor_campaigns` collection and `star_sponsored_links` mapping; sanitize and validate all fields.
-- Attribution: support UTM params and optional postback webhook; never block Star completion on sponsor availability.
+## Product pillars
 
----
+1. **Game Passport System** — one persistent character profile that can be exported read-only to connected games and experiences.
+2. **Stats, Level-Up & Atrophy** — six universal stats with current performance (`Ability Now`) separated from permanent long-term effort (`Legacy`).
+3. **Skill Universe** — galaxies, constellations, and stars that visualize real skills, milestones, perks, and credentials.
+4. **Cosmic Navigation Experience** — the Skill Universe should feel exploratory, alive, and space-travel inspired.
+5. **Ethical Monetization** — subscriptions, cosmetics, developer licensing, verification services, and contextual brand links without pay-to-win.
 
-© Codex Vitae
+## Canonical stat system
+
+Virtual Me uses six universal stats:
+
+| Stat | Name | Represents |
+| --- | --- | --- |
+| STR | Strength | Physical power and explosive force. |
+| DEX | Dexterity | Accuracy, coordination, fine control, and precision. |
+| CON | Constitution | Endurance, health, discipline, resilience, and stamina. |
+| INT | Intelligence | Learning, reasoning, problem-solving, and analysis. |
+| WIS | Wisdom | Awareness, planning, judgment, intuition, and decision-making. |
+| CHA | Charisma | Communication, leadership, persuasion, influence, and social presence. |
+
+Each stat has two tracks:
+
+- **Ability Now** — current active capability from `0–100`; it can rise or decay based on behavior.
+- **Legacy** — permanent lifetime effort; it never decreases.
+
+Progression rule of thumb: **1,000 fragments = +1 permanent stat point**, and **10 total permanent stat points = +1 character level**.
+
+## Star states
+
+The Skill Universe uses five canonical star states:
+
+| State | Meaning |
+| --- | --- |
+| `LOCKED` | Requirements are not met. |
+| `AVAILABLE` | Requirements are met and the user can unlock or verify the star. |
+| `OWNED` | The star has been unlocked permanently, but activation is not currently required or evaluated. |
+| `ACTIVE` | The star is owned and current Ability Now satisfies activation requirements. |
+| `PAUSED` | The star is owned, but current Ability Now or prerequisites have dropped below activation requirements. |
+
+Ownership is permanent. Activation can pause. Progress is never erased.
+
+## Visual direction
+
+- **Dashboard:** Animus-inspired identity interface — synchronization, memory reconstruction, holographic panels, scanlines, triangulated grids, and diagnostic HUD feedback.
+- **Skill Universe:** No Man’s Sky-inspired space travel — smooth camera movement, cosmic depth, scanner overlays, glowing stars, warp/arrival moments, and living constellations.
+
+## Current technical shape
+
+- Static web app entry: `index.html`
+- Legacy browser controller: `js/main.js`
+- Skill Universe data: `js/skill-tree-data.js`
+- Skill Universe renderer: `js/skill-universe-renderer.js`
+- Tested progression logic: `core/`
+- Backend chore classifier prototype: `cloud-function/`
+- Skill Universe asset pantry: `assets/skill-universe/`
+
+The current codebase is being reset toward the canonical Virtual Me direction. Some older names and internal keys may still exist during migration.
+
+## Local checks
+
+Install dependencies once:
+
+```bash
+npm install
+```
+
+Run the full check suite:
+
+```bash
+npm run check
+```
+
+Run tests only:
+
+```bash
+npm test -- --runInBand
+```
+
+Regenerate the Skill Universe asset manifest after changing material assets:
+
+```bash
+npm run generate:skill-library
+```
+
+## Product rules to preserve
+
+- Never design pay-to-win mechanics.
+- Never allow stat purchases.
+- Never allow skill unlocks through cash.
+- Separate permanent progress from current performance.
+- Legacy never decreases.
+- Ability Now can rise or decay based on real behavior.
+- Unlocking means ownership; current requirements determine activation.
+- Real-world evidence and credentials matter.
+- The user controls data sharing.
+- Developer access should be read-only unless explicitly authorized.
+- Brand links must be optional, contextual, transparent, and non-manipulative.

--- a/__tests__/virtualMe.test.ts
+++ b/__tests__/virtualMe.test.ts
@@ -1,0 +1,182 @@
+import {
+  addLegacyFragments,
+  createEmptyStatMap,
+  createReadOnlyGamePassportExport,
+  createStatTrack,
+  deriveCharacterLevel,
+  evaluateStarState,
+  normalizeStatType,
+  StarDefinition,
+  UserCharacter
+} from '../core/virtualMe';
+
+describe('Virtual Me canonical stat model', () => {
+  it('normalizes canonical stat names and legacy full names', () => {
+    expect(normalizeStatType('STR')).toBe('STR');
+    expect(normalizeStatType('strength')).toBe('STR');
+    expect(normalizeStatType('dexterity')).toBe('DEX');
+    expect(normalizeStatType('charisma')).toBe('CHA');
+    expect(normalizeStatType('unknown')).toBeNull();
+  });
+
+  it('rolls 1,000 fragments into permanent stat points without losing legacy', () => {
+    const starting = createStatTrack('STR', { fragments: 990, legacyPoints: 990, permanentStatPoints: 2 });
+    const result = addLegacyFragments(starting, 25);
+
+    expect(result.statPointsGained).toBe(1);
+    expect(result.track.fragments).toBe(15);
+    expect(result.track.legacyPoints).toBe(1015);
+    expect(result.track.permanentStatPoints).toBe(3);
+  });
+
+  it('derives character level from each 10 total permanent stat points', () => {
+    expect(deriveCharacterLevel(0)).toBe(1);
+    expect(deriveCharacterLevel(9)).toBe(1);
+    expect(deriveCharacterLevel(10)).toBe(2);
+    expect(deriveCharacterLevel(25)).toBe(3);
+  });
+});
+
+describe('Virtual Me star state evaluator', () => {
+  const star: StarDefinition = {
+    id: 'basic-fitness',
+    constellationId: 'body.fitness',
+    name: 'Basic Fitness',
+    description: 'Foundational strength habit.',
+    starType: 'MILESTONE',
+    requirements: {
+      requiredStats: { STR: 40 },
+      prerequisiteStarIds: ['warmup'],
+      perkPointCost: 1
+    }
+  };
+
+  it('returns LOCKED when unlock requirements are unmet', () => {
+    const evaluation = evaluateStarState(star, {
+      abilityNow: { STR: 35 },
+      ownedStarIds: ['warmup'],
+      availablePerkPoints: 1
+    });
+
+    expect(evaluation.state).toBe('LOCKED');
+    expect(evaluation.unmetUnlockRequirements).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: 'STAT', stat: 'STR' })])
+    );
+  });
+
+  it('returns AVAILABLE when requirements are met but the star is not owned', () => {
+    const evaluation = evaluateStarState(star, {
+      abilityNow: { STR: 41 },
+      ownedStarIds: ['warmup'],
+      availablePerkPoints: 1
+    });
+
+    expect(evaluation.state).toBe('AVAILABLE');
+    expect(evaluation.owned).toBe(false);
+  });
+
+  it('returns ACTIVE for owned stars that currently satisfy activation requirements', () => {
+    const evaluation = evaluateStarState(star, {
+      abilityNow: { STR: 41 },
+      ownedStarIds: ['warmup', 'basic-fitness'],
+      availablePerkPoints: 0
+    });
+
+    expect(evaluation.state).toBe('ACTIVE');
+    expect(evaluation.owned).toBe(true);
+    expect(evaluation.active).toBe(true);
+  });
+
+  it('returns PAUSED for owned stars when Ability Now drops below activation requirements', () => {
+    const evaluation = evaluateStarState(star, {
+      abilityNow: { STR: 20 },
+      ownedStarIds: ['warmup', 'basic-fitness'],
+      availablePerkPoints: 0
+    });
+
+    expect(evaluation.state).toBe('PAUSED');
+    expect(evaluation.owned).toBe(true);
+    expect(evaluation.active).toBe(false);
+    expect(evaluation.unmetActivationRequirements).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: 'STAT', stat: 'STR' })])
+    );
+  });
+
+  it('keeps credential stars LOCKED until required evidence is verified', () => {
+    const credentialStar: StarDefinition = {
+      id: 'bachelors-degree',
+      constellationId: 'mind.academics',
+      name: 'Bachelors Degree',
+      description: 'Verified degree credential.',
+      starType: 'CREDENTIAL',
+      requirements: {
+        requiredStats: { INT: 50 },
+        requiredEvidenceTypes: ['degree-document']
+      }
+    };
+
+    expect(
+      evaluateStarState(credentialStar, {
+        abilityNow: { INT: 60 },
+        verifiedEvidenceTypes: []
+      }).state
+    ).toBe('LOCKED');
+
+    expect(
+      evaluateStarState(credentialStar, {
+        abilityNow: { INT: 60 },
+        verifiedEvidenceTypes: ['degree-document']
+      }).state
+    ).toBe('AVAILABLE');
+  });
+
+  it('returns OWNED for owned stars with no activation requirements unless explicitly active', () => {
+    const passiveStar: StarDefinition = {
+      id: 'profile-badge',
+      constellationId: 'identity.badges',
+      name: 'Profile Badge',
+      description: 'A permanent identity marker.',
+      starType: 'MILESTONE'
+    };
+
+    const evaluation = evaluateStarState(passiveStar, {
+      abilityNow: {},
+      ownedStarIds: ['profile-badge']
+    });
+
+    expect(evaluation.state).toBe('OWNED');
+    expect(evaluation.owned).toBe(true);
+    expect(evaluation.active).toBe(false);
+  });
+});
+
+describe('Game Passport export', () => {
+  it('creates a read-only passport export from character state', () => {
+    const stats = createEmptyStatMap(10);
+    stats.STR = createStatTrack('STR', { abilityNow: 55, permanentStatPoints: 4 });
+    const character: UserCharacter = {
+      id: 'character-1',
+      userId: 'user-1',
+      displayName: 'Ezio Tester',
+      level: 1,
+      totalStatPoints: 12,
+      stats,
+      perkPoints: 2,
+      ownedStarIds: ['basic-fitness'],
+      activeStarIds: ['basic-fitness'],
+      verifiedCredentialStarIds: [],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-02T00:00:00.000Z'
+    };
+
+    const passport = createReadOnlyGamePassportExport(character, ['stats:read', 'stars:read']);
+
+    expect(passport.userId).toBe('user-1');
+    expect(passport.characterId).toBe('character-1');
+    expect(passport.level).toBe(2);
+    expect(passport.sharedStats.STR).toEqual({ abilityNow: 55, permanentStatPoints: 4 });
+    expect(passport.sharedStars).toEqual(['basic-fitness']);
+    expect(passport.sharedPerks).toEqual(['basic-fitness']);
+    expect(passport.permissions).toEqual(['stats:read', 'stars:read']);
+  });
+});

--- a/cloud-function/package-lock.json
+++ b/cloud-function/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "codex-vitae-backend",
+  "name": "virtual-me-origins-backend",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "codex-vitae-backend",
+      "name": "virtual-me-origins-backend",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/cloud-function/package.json
+++ b/cloud-function/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "codex-vitae-backend",
+  "name": "virtual-me-origins-backend",
   "version": "1.0.0",
-  "description": "Backend server for the Codex Vitae app.",
+  "description": "Backend server for the Virtual Me: Origins app.",
   "main": "index.js",
   "scripts": {
     "start": "node index.js"

--- a/config.js
+++ b/config.js
@@ -58,13 +58,6 @@
   // can fetch `/__/firebase/init.json` cross-origin without hardcoding secrets.
   const INLINE_RUNTIME_CONFIG = {
     firebaseConfig: {
-      apiKey: 'AIzaSyC11QPS3V1qZNGIQdEYp_Odsy5UoGl-fTo',
-      authDomain: 'codex-vitae-7b7c8.firebaseapp.com',
-      projectId: 'codex-vitae-7b7c8',
-      storageBucket: 'codex-vitae-7b7c8.appspot.com',
-      messagingSenderId: '1078938226885',
-      appId: '1:1078938226885:web:918e532b901f2390173f27',
-      measurementId: 'G-0E0Z4R2T73'
       apiKey: '',
       authDomain: '',
       projectId: '',
@@ -74,7 +67,7 @@
       measurementId: ''
     },
     backendUrl: '',
-    firebaseHostingOrigin: 'https://codex-vitae-470801.web.app'
+    firebaseHostingOrigin: ''
   };
 
   function cloneDefaultConfig() {

--- a/core/virtualMe.ts
+++ b/core/virtualMe.ts
@@ -1,0 +1,300 @@
+export const STAT_TYPES = ['STR', 'DEX', 'CON', 'INT', 'WIS', 'CHA'] as const;
+export type StatType = (typeof STAT_TYPES)[number];
+
+export const STAR_STATES = ['LOCKED', 'AVAILABLE', 'OWNED', 'ACTIVE', 'PAUSED'] as const;
+export type StarState = (typeof STAR_STATES)[number];
+
+export const ABILITY_NOW_MIN = 0;
+export const ABILITY_NOW_MAX = 100;
+export const LEGACY_FRAGMENTS_PER_STAT_POINT = 1000;
+export const STAT_POINTS_PER_CHARACTER_LEVEL = 10;
+
+export interface StatTrack {
+  type: StatType;
+  abilityNow: number;
+  legacyPoints: number;
+  permanentStatPoints: number;
+  fragments: number;
+  lastActivityAt?: string;
+  decayStatus?: 'STABLE' | 'AT_RISK' | 'DECAYING' | 'RECOVERING';
+  maintenanceThreshold?: number;
+}
+
+export interface UserCharacter {
+  id: string;
+  userId: string;
+  displayName: string;
+  level: number;
+  totalStatPoints: number;
+  stats: Record<StatType, StatTrack>;
+  perkPoints: number;
+  ownedStarIds: string[];
+  activeStarIds: string[];
+  verifiedCredentialStarIds: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type StarType = 'MILESTONE' | 'APEX' | 'CREDENTIAL';
+
+export interface StarRequirements {
+  requiredStats?: Partial<Record<StatType, number>>;
+  prerequisiteStarIds?: string[];
+  requiredEvidenceTypes?: string[];
+  perkPointCost?: number;
+}
+
+export interface StarDefinition {
+  id: string;
+  constellationId: string;
+  name: string;
+  description: string;
+  starType: StarType;
+  requirements?: StarRequirements;
+  activationRequirements?: StarRequirements;
+  brandLinks?: string[];
+}
+
+export interface StarEvaluationContext {
+  abilityNow: Partial<Record<StatType, number>>;
+  ownedStarIds?: string[];
+  activeStarIds?: string[];
+  verifiedCredentialStarIds?: string[];
+  verifiedEvidenceTypes?: string[];
+  availablePerkPoints?: number;
+}
+
+export interface RequirementFailure {
+  type: 'STAT' | 'PREREQUISITE_STAR' | 'EVIDENCE' | 'PERK_POINT';
+  stat?: StatType;
+  required?: number;
+  current?: number;
+  starId?: string;
+  evidenceType?: string;
+  requiredPoints?: number;
+  availablePoints?: number;
+}
+
+export interface StarEvaluationResult {
+  state: StarState;
+  owned: boolean;
+  active: boolean;
+  unmetUnlockRequirements: RequirementFailure[];
+  unmetActivationRequirements: RequirementFailure[];
+}
+
+const LEGACY_STAT_ALIASES: Record<string, StatType> = {
+  STRENGTH: 'STR',
+  STR: 'STR',
+  DEXTERITY: 'DEX',
+  DEX: 'DEX',
+  CONSTITUTION: 'CON',
+  CON: 'CON',
+  INTELLIGENCE: 'INT',
+  INT: 'INT',
+  WISDOM: 'WIS',
+  WIS: 'WIS',
+  CHARISMA: 'CHA',
+  CHA: 'CHA'
+};
+
+export function normalizeStatType(value: string): StatType | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.trim().toUpperCase();
+  return LEGACY_STAT_ALIASES[normalized] ?? null;
+}
+
+export function clampAbilityNow(value: number): number {
+  if (!Number.isFinite(value)) {
+    return ABILITY_NOW_MIN;
+  }
+  return Math.max(ABILITY_NOW_MIN, Math.min(ABILITY_NOW_MAX, Math.round(value)));
+}
+
+export function normalizeFragments(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(LEGACY_FRAGMENTS_PER_STAT_POINT - 1, Math.floor(value)));
+}
+
+export function createStatTrack(type: StatType, overrides: Partial<StatTrack> = {}): StatTrack {
+  return {
+    type,
+    abilityNow: clampAbilityNow(overrides.abilityNow ?? 0),
+    legacyPoints: Math.max(0, Math.floor(overrides.legacyPoints ?? 0)),
+    permanentStatPoints: Math.max(0, Math.floor(overrides.permanentStatPoints ?? 0)),
+    fragments: normalizeFragments(overrides.fragments ?? 0),
+    lastActivityAt: overrides.lastActivityAt,
+    decayStatus: overrides.decayStatus,
+    maintenanceThreshold: Number.isFinite(overrides.maintenanceThreshold)
+      ? Math.max(0, Number(overrides.maintenanceThreshold))
+      : undefined
+  };
+}
+
+export function createEmptyStatMap(defaultAbilityNow = 0): Record<StatType, StatTrack> {
+  return STAT_TYPES.reduce((stats, type) => {
+    stats[type] = createStatTrack(type, { abilityNow: defaultAbilityNow });
+    return stats;
+  }, {} as Record<StatType, StatTrack>);
+}
+
+export function deriveCharacterLevel(totalStatPoints: number): number {
+  if (!Number.isFinite(totalStatPoints) || totalStatPoints <= 0) {
+    return 1;
+  }
+  return Math.floor(totalStatPoints / STAT_POINTS_PER_CHARACTER_LEVEL) + 1;
+}
+
+export function addLegacyFragments(track: StatTrack, amount: number): { track: StatTrack; statPointsGained: number } {
+  const safeAmount = Number.isFinite(amount) ? Math.max(0, Math.floor(amount)) : 0;
+  const rawFragments = normalizeFragments(track.fragments) + safeAmount;
+  const statPointsGained = Math.floor(rawFragments / LEGACY_FRAGMENTS_PER_STAT_POINT);
+  const fragments = rawFragments % LEGACY_FRAGMENTS_PER_STAT_POINT;
+  const legacyPoints = Math.max(0, Math.floor(track.legacyPoints || 0)) + safeAmount;
+  const permanentStatPoints = Math.max(0, Math.floor(track.permanentStatPoints || 0)) + statPointsGained;
+
+  return {
+    statPointsGained,
+    track: createStatTrack(track.type, {
+      ...track,
+      fragments,
+      legacyPoints,
+      permanentStatPoints
+    })
+  };
+}
+
+function evaluateRequirements(
+  requirements: StarRequirements | undefined,
+  context: StarEvaluationContext,
+  options: { includePerkCost: boolean; includeEvidence: boolean }
+): RequirementFailure[] {
+  const failures: RequirementFailure[] = [];
+  const req = requirements ?? {};
+  const ownedStarIds = new Set(context.ownedStarIds ?? []);
+  const verifiedEvidenceTypes = new Set(context.verifiedEvidenceTypes ?? []);
+
+  for (const [rawStat, requiredValue] of Object.entries(req.requiredStats ?? {})) {
+    const stat = normalizeStatType(rawStat);
+    if (!stat || requiredValue === undefined) {
+      continue;
+    }
+    const required = Math.max(0, Number(requiredValue));
+    const current = clampAbilityNow(context.abilityNow[stat] ?? 0);
+    if (current < required) {
+      failures.push({ type: 'STAT', stat, required, current });
+    }
+  }
+
+  for (const starId of req.prerequisiteStarIds ?? []) {
+    if (!ownedStarIds.has(starId)) {
+      failures.push({ type: 'PREREQUISITE_STAR', starId });
+    }
+  }
+
+  if (options.includeEvidence) {
+    for (const evidenceType of req.requiredEvidenceTypes ?? []) {
+      if (!verifiedEvidenceTypes.has(evidenceType)) {
+        failures.push({ type: 'EVIDENCE', evidenceType });
+      }
+    }
+  }
+
+  if (options.includePerkCost && Number.isFinite(req.perkPointCost) && Number(req.perkPointCost) > 0) {
+    const requiredPoints = Math.max(0, Math.floor(Number(req.perkPointCost)));
+    const availablePoints = Math.max(0, Math.floor(context.availablePerkPoints ?? 0));
+    if (availablePoints < requiredPoints) {
+      failures.push({ type: 'PERK_POINT', requiredPoints, availablePoints });
+    }
+  }
+
+  return failures;
+}
+
+export function evaluateStarState(star: StarDefinition, context: StarEvaluationContext): StarEvaluationResult {
+  const ownedStarIds = new Set(context.ownedStarIds ?? []);
+  const activeStarIds = new Set(context.activeStarIds ?? []);
+  const owned = ownedStarIds.has(star.id);
+
+  const unmetUnlockRequirements = evaluateRequirements(star.requirements, context, {
+    includePerkCost: true,
+    includeEvidence: true
+  });
+
+  if (!owned) {
+    return {
+      state: unmetUnlockRequirements.length === 0 ? 'AVAILABLE' : 'LOCKED',
+      owned: false,
+      active: false,
+      unmetUnlockRequirements,
+      unmetActivationRequirements: []
+    };
+  }
+
+  const activationRequirements = star.activationRequirements ?? star.requirements;
+  const unmetActivationRequirements = evaluateRequirements(activationRequirements, context, {
+    includePerkCost: false,
+    includeEvidence: false
+  });
+  const active = unmetActivationRequirements.length === 0;
+
+  if (!activationRequirements || Object.keys(activationRequirements).length === 0) {
+    return {
+      state: activeStarIds.has(star.id) ? 'ACTIVE' : 'OWNED',
+      owned: true,
+      active: activeStarIds.has(star.id),
+      unmetUnlockRequirements: [],
+      unmetActivationRequirements: []
+    };
+  }
+
+  return {
+    state: active ? 'ACTIVE' : 'PAUSED',
+    owned: true,
+    active,
+    unmetUnlockRequirements: [],
+    unmetActivationRequirements
+  };
+}
+
+export interface GamePassportExport {
+  userId: string;
+  characterId: string;
+  displayName: string;
+  level: number;
+  sharedStats: Record<StatType, { abilityNow: number; permanentStatPoints: number }>;
+  sharedStars: string[];
+  sharedPerks: string[];
+  permissions: string[];
+  exportedAt: string;
+}
+
+export function createReadOnlyGamePassportExport(
+  character: UserCharacter,
+  permissions: string[] = []
+): GamePassportExport {
+  const sharedStats = STAT_TYPES.reduce((stats, type) => {
+    const track = character.stats[type] ?? createStatTrack(type);
+    stats[type] = {
+      abilityNow: clampAbilityNow(track.abilityNow),
+      permanentStatPoints: Math.max(0, Math.floor(track.permanentStatPoints || 0))
+    };
+    return stats;
+  }, {} as GamePassportExport['sharedStats']);
+
+  return {
+    userId: character.userId,
+    characterId: character.id,
+    displayName: character.displayName,
+    level: deriveCharacterLevel(character.totalStatPoints),
+    sharedStats,
+    sharedStars: [...character.ownedStarIds],
+    sharedPerks: [...character.activeStarIds],
+    permissions: [...permissions],
+    exportedAt: new Date().toISOString()
+  };
+}

--- a/docs/PRODUCT_CODEX.md
+++ b/docs/PRODUCT_CODEX.md
@@ -1,0 +1,186 @@
+# Virtual Me: Origins Product Codex
+
+This document is the canonical direction for the reset of the former Codex Vitae prototype. **Virtual Me: Origins** is the product name for the platform, app, and identity system.
+
+## North Star
+
+**One Character, Many Worlds. Your progress follows you.**
+
+Virtual Me: Origins is a real-life character identity infrastructure layer. A user’s actual habits, achievements, skills, credentials, and personal growth become a persistent game-like identity that can connect to games, apps, education, career systems, and personal development tools.
+
+The player is the save file.
+
+## 1. Game Passport System
+
+The Game Passport gives each user one persistent character profile that stores:
+
+- six universal stats: STR, DEX, CON, INT, WIS, CHA;
+- Ability Now values;
+- Legacy values;
+- Skill Universe progress;
+- unlocked, owned, active, and paused stars/perks;
+- achievements;
+- verified credentials;
+- history and activity logs;
+- privacy permissions for connected experiences.
+
+Connected games should read the passport with user permission and adapt their experience without manual setup. Games can interpret the same stats differently by genre through soft caps, scaling curves, stat mappings, and star mappings.
+
+Developer integration principles:
+
+- open;
+- modular;
+- optional;
+- read-only by default;
+- opt-in per game;
+- flexible for RPGs, strategy games, simulations, narrative games, and other genres.
+
+Security and trust principles:
+
+- only authentic progress should count;
+- no stat editing or stat injection;
+- verified credentials matter;
+- anti-cheat and fraud detection are required for competitive contexts;
+- the player controls what data is shared.
+
+## 2. Stat, Level-Up & Atrophy System
+
+Core philosophy: **Growth, not grinding.**
+
+Stats represent foundational human capacities, not narrow isolated skills.
+
+| Stat | Name | Represents |
+| --- | --- | --- |
+| STR | Strength | Physical strength and explosive power. |
+| DEX | Dexterity | Accuracy, fine control, coordination, and precision. |
+| CON | Constitution | Endurance, health, discipline, resilience, and stamina. |
+| INT | Intelligence | Learning, reasoning, problem-solving, and analytical thinking. |
+| WIS | Wisdom | Awareness, planning, judgment, intuition, and decision-making. |
+| CHA | Charisma | Communication, leadership, persuasion, influence, and social presence. |
+
+Each stat has two parallel tracks:
+
+### Ability Now
+
+- Range: `0–100`.
+- Represents current active capability.
+- Responds quickly to behavior changes.
+- Can increase or decrease over time.
+- Used for perk activation, gameplay checks, and moment-to-moment performance.
+
+### Legacy
+
+- Permanent long-term record of effort.
+- Each stat has its own Legacy track.
+- Never decreases.
+- Represents accumulated effort over time.
+- Used for permanent stat increases, perk ownership, and mastery recognition.
+
+Stat growth flow:
+
+1. The user logs a real activity or habit.
+2. The activity is classified to a stat.
+3. Effort generates stat fragments.
+4. `1,000 fragments = +1 permanent stat point`.
+5. `10 total permanent stat points = +1 character level`.
+
+Atrophy affects Ability Now only. Higher stats require more maintenance. Legacy is never affected by atrophy.
+
+## 3. Skill Universe System
+
+The Skill Universe is a living map of who the user is becoming.
+
+Hierarchy:
+
+- **Galaxy** — a major domain of life, such as Mind, Body, Soul, or Social.
+- **Constellation** — a themed path inside a galaxy.
+- **Star** — an individual skill, perk, verified achievement, milestone, or apex accomplishment.
+
+Star types:
+
+- **Milestone Stars** — foundational or intermediate progress.
+- **Apex Stars** — rare peak achievements that define identity and specialization.
+- **Credential Stars** — achievements requiring evidence or verification.
+
+Canonical star states:
+
+| State | Meaning |
+| --- | --- |
+| `LOCKED` | Requirements are not met. |
+| `AVAILABLE` | Requirements are met and the user can unlock or verify the star. |
+| `OWNED` | The star is permanently unlocked, but activation is not currently evaluated or required. |
+| `ACTIVE` | The star is owned and current requirements are satisfied. |
+| `PAUSED` | The star is owned, but current Ability Now or prerequisite requirements are not currently satisfied. |
+
+Ownership vs activation is mandatory:
+
+- unlocking means ownership;
+- activation depends on current requirements;
+- if Ability Now drops below requirements, the star or perk pauses;
+- paused progress is not erased.
+
+## 4. Visual / Navigation Experience
+
+Dashboard target: **Animus-inspired identity interface**.
+
+- synchronization language;
+- memory reconstruction;
+- holographic panels;
+- scanlines;
+- triangulated grids;
+- diagnostic HUD notifications;
+- high-trust system feel.
+
+Skill Universe target: **No Man’s Sky-inspired cosmic exploration**.
+
+- fully navigable space;
+- smooth camera travel through Galaxy → Constellation → Star;
+- no hard cuts;
+- stars pulse, connect, and light up;
+- warm glow for available stars;
+- cool vibrant light for active/unlocked stars;
+- locked stars are dim and distant;
+- scanner overlays and warp/arrival moments.
+
+The visual experience is identity visualization, not normal UI.
+
+## 5. Monetization Rules
+
+Monetization must protect trust.
+
+Never allow:
+
+- pay-to-win mechanics;
+- stat purchases;
+- cash skill unlocks;
+- brand manipulation of progression;
+- behavioral targeting;
+- forced brand engagement.
+
+Allowed monetization pillars:
+
+- optional player subscriptions for analytics, history, verification speed, and customization;
+- developer licensing and SDK/API access;
+- cosmetic and identity customization;
+- marketplace fees for visual packs and profile presentation;
+- contextual brand links that are optional, transparent, capped, and relevant;
+- credential and verification services;
+- enterprise and institutional licensing.
+
+## MVP Priority
+
+1. Core character profile.
+2. Six stats: STR, DEX, CON, INT, WIS, CHA.
+3. Ability Now and Legacy separation.
+4. Activity logging.
+5. Fragment-to-stat conversion.
+6. Basic level calculation.
+7. Basic Skill Universe hierarchy.
+8. Star states: LOCKED, AVAILABLE, OWNED, ACTIVE, PAUSED.
+9. Stat requirements for stars.
+10. Perk Point spending.
+11. Simple visual Skill Universe map.
+12. Read-only Game Passport export.
+13. Privacy/data sharing controls.
+
+Monetization should not lead the build. The foundation is trust, progression, and identity.

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Codex Vitae</title>
+    <title>Virtual Me: Origins</title>
     <link rel="stylesheet" href="CSS/style.css">
     <script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
     <script type="importmap">
@@ -18,7 +18,7 @@
 <body>
 
     <div id="auth-screen">
-        <h1>Codex Vitae</h1>
+        <h1>Virtual Me: Origins</h1>
         <input type="email" id="email-input" placeholder="Email">
         <input type="password" id="password-input" placeholder="Password">
         <button id="login-btn" type="button">Login</button>
@@ -26,11 +26,15 @@
     </div>
 
     <div id="app-screen" class="hidden">
-        <h2>Welcome to Your Codex</h2>
+        <header class="animus-shell-header" aria-label="Virtual Me identity synchronization status">
+            <div class="animus-kicker">Virtual Me: Origins</div>
+            <h2>Identity Synchronization</h2>
+            <p>Animus shell online — reconstructing your real-world character passport.</p>
+        </header>
 
         <div id="legacy-level-section" class="widget level-card" role="region" aria-label="Legacy Level">
             <div class="level-card-header">
-                <h3>Legacy Level</h3>
+                <h3>Legacy Archive</h3>
                 <div class="legacy-level-display">
                     <span class="legacy-level-label">Lvl</span>
                     <span id="legacy-level">0</span>
@@ -63,11 +67,11 @@
         </div>
 
         <div id="face-scan-section" class="widget">
-            <button id="scan-face-btn">Scan Your Face &amp; Body</button>
+            <button id="scan-face-btn">Begin Identity Scan</button>
         </div>
 
         <div id="stat-panel" class="widget" role="region" aria-label="Ability stats">
-            <h3>Ability Stats</h3>
+            <h3>Ability Now Matrix</h3>
             <div id="stat-rows" class="stat-rows" aria-live="polite">
                 <div class="stat-row" data-stat="pwr">
                     <div class="stat-row-header">
@@ -181,12 +185,12 @@
         </div>
 
         <div id="maintenance-card" class="widget maintenance-card" role="region" aria-live="polite">
-            <h3>Atrophy &amp; Maintenance</h3>
+            <h3>Atrophy &amp; Maintenance Signals</h3>
             <p id="maintenance-message">Loading personalized guidance…</p>
         </div>
 
         <div id="perk-panel" class="widget" role="region" aria-label="Perk Progression">
-            <h3>Perk Progression</h3>
+            <h3>Perk Activation Ledger</h3>
             <div class="perk-progress-summary">
                 <div class="perk-points-available">
                     <span class="meta-label">Perk Points Available</span>
@@ -221,11 +225,11 @@
         </div>
 
         <div id="chore-section" class="widget">
-            <h4>Log Your Chores</h4>
-            <p class="widget-subtitle">Record the actions that build your Legacy Level.</p>
+            <h4>Record Memory Fragment</h4>
+            <p class="widget-subtitle">Synchronize real actions into Legacy fragments and Ability signals.</p>
 
             <div id="add-chore-input-group" class="input-group">
-                <input type="text" id="chore-input" placeholder="Log a completed chore and press Enter...">
+                <input type="text" id="chore-input" placeholder="Describe a completed real-world action and press Enter...">
                 <label for="chore-stat-select" class="visually-hidden">Select chore stat</label>
                 <select id="chore-stat-select" aria-label="Select a stat for this chore">
                     <option value="">Auto (AI / keywords)</option>
@@ -298,8 +302,10 @@
             <ul id="chore-list" class="chore-list"></ul>
         </div>
 
-        <button id="open-codex-btn">Open Codex</button>
+        <button id="open-codex-btn">Open Skill Universe</button>
     </div>
+
+    <div id="hud-toast-region" class="hud-toast-region" aria-live="polite" aria-atomic="false"></div>
 
     <div id="onboarding-modal" class="modal hidden">
         <div class="modal-content">
@@ -371,9 +377,9 @@
 
     <div id="codex-modal" class="modal hidden">
         <div class="modal-content">
-            <h2>Codex Menu</h2>
+            <h2>Virtual Me Menu</h2>
             <div class="codex-menu">
-                <button id="codex-skills-btn">Constellation Skills</button>
+                <button id="codex-skills-btn">Enter Skill Universe</button>
                 <button id="codex-logout-btn">Logout</button>
             </div>
             <button id="close-codex-btn">Close</button>

--- a/js/main.js
+++ b/js/main.js
@@ -11,7 +11,7 @@
         try {
             await codexConfigReady;
         } catch (error) {
-            console.error('Failed to resolve Codex Vitae runtime configuration before app start.', error);
+            console.error('Failed to resolve Virtual Me: Origins runtime configuration before app start.', error);
         }
     }
 function displayConfigurationError(message, details) {
@@ -25,7 +25,7 @@ function displayConfigurationError(message, details) {
         : '';
 
     authScreenElement.innerHTML = `
-        <h1>Codex Vitae</h1>
+        <h1>Virtual Me: Origins</h1>
         <p class="config-error-message">${message}</p>
         ${extraDetails}
         <p>Update the placeholders in <code>config.js</code> or provide a <code>config.runtime.json</code> file with your Firebase project values.</p>
@@ -36,10 +36,10 @@ const codexConfig = window.__CODEX_CONFIG__;
 
 if (!codexConfig || typeof codexConfig !== 'object') {
     displayConfigurationError(
-        'Codex Vitae configuration is missing.',
+        'Virtual Me: Origins configuration is missing.',
         'Define <code>window.__CODEX_CONFIG__</code> in config.js before loading the app.'
     );
-    console.error('Codex Vitae configuration is missing. Define window.__CODEX_CONFIG__ in config.js.');
+    console.error('Virtual Me: Origins configuration is missing. Define window.__CODEX_CONFIG__ in config.js.');
     return;
 }
 
@@ -100,7 +100,7 @@ if (!firebaseConfig || typeof firebaseConfig !== 'object') {
 
 if (!AI_FEATURES_AVAILABLE) {
     console.warn(
-        'Codex Vitae backendUrl is not configured. AI-powered features will be disabled until it is set.'
+        'Virtual Me: Origins backendUrl is not configured. AI-powered features will be disabled until it is set.'
     );
 }
 
@@ -2243,7 +2243,7 @@ async function loadData(userId) {
             webcamFeed.classList.add('hidden');
         }
         if (scanButton) {
-            scanButton.textContent = characterData.avatarUrl ? 'Update Avatar' : 'Scan Your Face & Body';
+            scanButton.textContent = characterData.avatarUrl ? 'Update Identity Scan' : 'Begin Identity Scan';
         }
 
         syncSkillSearchInputWithTarget(characterData.skillSearchTarget);
@@ -2389,7 +2389,7 @@ async function handleFaceScan() {
             scanButton.textContent = 'Capture';
         } catch (error) {
             console.error('Webcam access error:', error);
-            alert("Could not access webcam. Please ensure you've given permission.");
+            showToast("Could not access webcam. Please ensure you've given permission.", { variant: 'warning' });
         }
         return;
     }
@@ -2426,7 +2426,7 @@ async function handleFaceScan() {
         updateDashboard();
     } catch (error) {
         console.error('Avatar generation failed:', error);
-        alert('Avatar generation failed. Try again later.');
+        showToast('Avatar generation failed. Try again later.', { variant: 'warning' });
     } finally {
         if (webcamFeed) {
             webcamFeed.classList.add('hidden');
@@ -2434,7 +2434,7 @@ async function handleFaceScan() {
         }
         updateCapturedPhotoElement(capturedPhoto, characterData.avatarUrl);
         if (scanButton) {
-            scanButton.textContent = characterData.avatarUrl ? 'Update Avatar' : 'Scan Your Face & Body';
+            scanButton.textContent = characterData.avatarUrl ? 'Update Identity Scan' : 'Begin Identity Scan';
             scanButton.disabled = false;
         }
     }
@@ -2503,7 +2503,7 @@ function updateDashboard() {
         webcamFeed.classList.add('hidden');
     }
     if (scanButton) {
-        scanButton.textContent = characterData.avatarUrl ? 'Update Avatar' : 'Scan Your Face & Body';
+        scanButton.textContent = characterData.avatarUrl ? 'Update Identity Scan' : 'Begin Identity Scan';
     }
 
     if (auth.currentUser) saveData();
@@ -2817,8 +2817,43 @@ function updateSkillTreeUI(title, breadcrumbs, showBack) {
     skillBackBtn.classList.toggle('hidden', !showBack);
 }
 
-function showToast(message) {
-    alert(message);
+function renderHudToast(message, options = {}) {
+    const text = typeof message === 'string' ? message.trim() : String(message || '').trim();
+    if (!text) {
+        return;
+    }
+
+    let region = document.getElementById('hud-toast-region');
+    if (!region) {
+        region = document.createElement('div');
+        region.id = 'hud-toast-region';
+        region.className = 'hud-toast-region';
+        region.setAttribute('aria-live', 'polite');
+        region.setAttribute('aria-atomic', 'false');
+        document.body.appendChild(region);
+    }
+
+    const toast = document.createElement('div');
+    toast.className = 'hud-toast';
+    toast.dataset.variant = typeof options.variant === 'string' ? options.variant : 'sync';
+    toast.innerHTML = `
+        <span class="hud-toast-label">ANIMUS SIGNAL</span>
+        <span class="hud-toast-message"></span>
+    `;
+    const messageElement = toast.querySelector('.hud-toast-message');
+    if (messageElement) {
+        messageElement.textContent = text;
+    }
+
+    region.appendChild(toast);
+    window.setTimeout(() => {
+        toast.classList.add('is-dismissing');
+        window.setTimeout(() => toast.remove(), 260);
+    }, Number.isFinite(options.duration) ? options.duration : 4200);
+}
+
+function showToast(message, options) {
+    renderHudToast(message, options);
 }
 
 function findSkillTreePath(query) {
@@ -3225,10 +3260,6 @@ function requestSkillPath(path) {
 }
 
 window.requestSkillPath = requestSkillPath;
-
-function showToast(message) {
-    alert(message);
-}
 
 function determineStarStatus(starName, starData) {
     if (!starData || !characterData) {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "codex-vitae",
+  "name": "virtual-me-origins",
   "version": "1.0.0",
-  "description": "Codex Vitae web app",
+  "description": "Virtual Me: Origins web app",
   "scripts": {
     "test": "jest",
-    "generate:skill-library": "node tools/build-skill-universe-library.js"
+    "generate:skill-library": "node tools/build-skill-universe-library.js",
+    "check": "node --check config.js && node --check js/main.js && node --check js/skill-tree-data.js && node --check js/skill-universe-star-mixer.js && node --check js/skill-universe-renderer.js && node --check cloud-function/index.js && tsc --noEmit && npm test -- --runInBand"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",


### PR DESCRIPTION
### Motivation
- Rename and refocus the project from the Codex Vitae prototype to the Virtual Me: Origins product and provide a canonical product codex and visual direction.
- Replace hardcoded runtime credentials and improve configuration hygiene by clearing inline secrets in `config.js`.
- Implement a canonical stat/skill model and evaluation primitives so the UI and integrations can rely on a consistent core domain layer.
- Improve UX with a new Animus-inspired dashboard theme and a non-blocking HUD toast system for in-app messaging.

### Description
- Add a typed core library `core/virtualMe.ts` implementing stat tracks, fragment-to-point conversion, level derivation, star evaluation logic, normalization helpers, and a read-only Game Passport export API.
- Add unit tests in `__tests__/virtualMe.test.ts` exercising normalization, fragment rollups, level derivation, star state evaluation (LOCKED/AVAILABLE/OWNED/ACTIVE/PAUSED), credential handling, and the passport export.
- Replace product copy and UI labels across `index.html` and `js/main.js` to reflect "Virtual Me: Origins", update skill/codex button text, onboarding and chore placeholders, and scan flow labels.
- Introduce a new Animus visual shell in `CSS/style.css` (colors, grid, hud, app layout, widgets, avatar stage, responsive rules) and add toast region markup to `index.html`.
- Replace blocking `alert()` calls with a HUD toast implementation (`renderHudToast` / `showToast`) and use it for webcam and avatar-generation errors in `js/main.js`.
- Remove inline Firebase keys and hosting origin values from `config.js` to avoid shipping secrets and to require runtime configuration instead.
- Rename package and backend identifiers in `package.json` and `cloud-function/package*.json` and add a `check` script in `package.json` to run static checks and tests.
- Add `docs/PRODUCT_CODEX.md` and expand `README.md` to capture product pillars, canonical stats, star states, and integration guidance.

### Testing
- Added Jest unit tests in `__tests__/virtualMe.test.ts` and executed them with `npm test`, and the suite completed successfully (all tests passed).
- The new `core/virtualMe.ts` was exercised by the added tests which validated fragment rollup, stat normalization, level derivation, star evaluation cases, credential gating, and passport export formatting.
- The repository `package.json` was updated with a `check` script to run static checks and `tsc` type checking, which can be used for CI validation (not executed during this PR run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a07dae706848328b790d0ae7fd0f34b)